### PR TITLE
added multipler for normalization to Config and CLI

### DIFF
--- a/src/application/main.cpp
+++ b/src/application/main.cpp
@@ -64,6 +64,7 @@ static void usage( const char* argv )
          << "                             Computed filter width are lower than VLFeat/PopSift" << endl
          << " --root-sift                 Use the L1-based norm for OpenMVG rather than" << endl
          << "                             L2-based as in OpenCV" << endl
+         << " --norm-multi=<int>          Multiply the descriptor by pow(2,<int>), default 0" << endl
          << " --dp-off                    Switch all CUDA Dynamic Parallelism off" << endl
          << " --dp-ori-off                Switch DP off for orientation computation" << endl
          << " --dp-desc-off               Switch DP off for descriptor computation" << endl
@@ -107,6 +108,7 @@ static struct option longopts[] = {
     { "dp-ori-off",          no_argument,            NULL, 1106 },
     { "dp-desc-off",         no_argument,            NULL, 1107 },
     { "root-sift",           no_argument,            NULL, 1108 },
+    { "norm-multi",          required_argument,      NULL, 1109 },
 
     { "print-gauss-tables",  no_argument,            NULL, 1200 },
     { "print-dev-info",      no_argument,            NULL, 1201 },
@@ -154,6 +156,7 @@ static void parseargs( int argc, char**argv, popsift::Config& config, string& in
         case 1106 : config.setDPOrientation( false ); break;
         case 1107 : config.setDPDescriptors( false ); break;
         case 1108 : config.setUseRootSift( true ); break;
+        case 1109 : config.setNormalizationMultiplier( strtol( optarg, NULL, 0 ) ); break;
 
         case 1200 : config.setPrintGaussTables( ); break;
         case 1201 : print_dev_info  = true; break;

--- a/src/popsift/popsift.cu
+++ b/src/popsift/popsift.cu
@@ -17,24 +17,13 @@
 using namespace std;
 
 PopSift::PopSift( const popsift::Config& config )
-    : _config( config )
 {
-    _config.levels = max( 2, config.levels );
-
-    popsift::init_filter( _config,
-                         _config.sigma,
-                         _config.levels );
-    popsift::init_constants(  _config.sigma,
-                             _config.levels,
-                             _config.getPeakThreshold(),
-                             _config._edge_limit,
-                             10000, // max extrema
-                             _config.getNormalizationMultiplier() );
-
     for( int i=0; i<MAX_PIPES; i++ ) {
         _pipe[i]._inputImage = 0;
         _pipe[i]._pyramid    = 0;
     }
+
+    configure(config);
 }
 
 PopSift::PopSift( )

--- a/src/popsift/popsift.cu
+++ b/src/popsift/popsift.cu
@@ -28,7 +28,8 @@ PopSift::PopSift( const popsift::Config& config )
                              _config.levels,
                              _config.getPeakThreshold(),
                              _config._edge_limit,
-                             10000 ); // max extrema
+                             10000, // max extrema
+                             _config.getNormalizationMultiplier() );
 }
 
 PopSift::~PopSift()

--- a/src/popsift/popsift.cu
+++ b/src/popsift/popsift.cu
@@ -18,7 +18,6 @@ using namespace std;
 
 PopSift::PopSift( const popsift::Config& config )
     : _config( config )
-    , _configured( true )
     , _initialized( false )
 {
     _config.levels = max( 2, config.levels );
@@ -35,7 +34,6 @@ PopSift::PopSift( const popsift::Config& config )
 }
 
 PopSift::PopSift( )
-    : _configured( false )
     , _initialized( false )
 { }
 
@@ -44,10 +42,7 @@ PopSift::~PopSift()
 
 bool PopSift::configure( const popsift::Config& config )
 {
-    if( _configured ) return false;
     if( _initialized ) return false;
-
-    _configured = true;
 
     _config = config;
 
@@ -67,8 +62,6 @@ bool PopSift::configure( const popsift::Config& config )
 
 bool PopSift::init( int pipe, int w, int h, bool checktime )
 {
-    if( not _configured ) return false;
-
     if( _initialized ) return false;
 
     cudaEvent_t start, end;
@@ -133,7 +126,6 @@ popsift::Features* PopSift::execute( int                  pipe,
                                      const unsigned char* imageData,
                                      bool                 checktime )
 {
-    if( not _configured ) return 0;
     if( not _initialized ) return 0;
 
     if( pipe < 0 && pipe >= MAX_PIPES ) return 0;

--- a/src/popsift/popsift.h
+++ b/src/popsift/popsift.h
@@ -37,11 +37,17 @@ public:
     /* We support more than 1 streams, but we support only one sigma and one
      * level parameters.
      */
+    PopSift( );
     PopSift( const popsift::Config& config );
     ~PopSift();
 
 public:
+    /* provide the configuration if you used the PopSift constructor */
+    bool configure( const popsift::Config& config );
+
     bool init( int pipe, int w, int h, bool checktime = false );
+
+    void uninit( int pipe );
 
 #if 1
     popsift::Features* execute( int                  pipe,
@@ -60,10 +66,10 @@ public:
         return *_pipe[pipe]._pyramid;
     }
 
-    void uninit( int pipe );
-
 private:
-    Pipe           _pipe[MAX_PIPES];
+    Pipe            _pipe[MAX_PIPES];
     popsift::Config _config;
+    bool            _configured;
+    bool            _initialized;
 };
 

--- a/src/popsift/popsift.h
+++ b/src/popsift/popsift.h
@@ -69,7 +69,5 @@ public:
 private:
     Pipe            _pipe[MAX_PIPES];
     popsift::Config _config;
-    bool            _configured;
-    bool            _initialized;
 };
 

--- a/src/popsift/sift_conf.cu
+++ b/src/popsift/sift_conf.cu
@@ -26,6 +26,7 @@ Config::Config( )
     , _assume_initial_blur( false )
     , _initial_blur( 0.0f )
     , _use_root_sift( false )
+    , _normalization_multiplier( 0 )
     , _print_gauss_tables( false )
     , _dp_orientation( true )
     , _dp_descriptors( true )
@@ -76,6 +77,7 @@ void Config::setPrintGaussTables() { _print_gauss_tables = true; }
 void Config::setDPOrientation( bool onoff ) { _dp_orientation = onoff; }
 void Config::setDPDescriptors( bool onoff ) { _dp_descriptors = onoff; }
 void Config::setUseRootSift( bool on ) { _use_root_sift = on; }
+void Config::setNormalizationMultiplier( int mul ) { _normalization_multiplier = mul; }
 
 void Config::setInitialBlur( float blur )
 {

--- a/src/popsift/sift_conf.h
+++ b/src/popsift/sift_conf.h
@@ -50,6 +50,7 @@ struct Config
     void setPrintGaussTables( );
     void setDPOrientation( bool on );
     void setDPDescriptors( bool on );
+    void setNormalizationMultiplier( int mul );
 
     bool  hasInitialBlur( ) const;
     float getInitialBlur( ) const;
@@ -83,15 +84,19 @@ struct Config
     // default edge_limit 10.0f from Bemap
     float    _edge_limit;
 
-    bool getUseRootSift( ) const {
+    inline bool getUseRootSift( ) const {
         return _use_root_sift;
     }
 
     /* The input image is stretched by 2^upscale_factor
      * before processing. The factor 1 is default.
      */
-    float getUpscaleFactor( ) const {
+    inline float getUpscaleFactor( ) const {
         return _upscale_factor;
+    }
+
+    int getNormalizationMultiplier( ) const {
+        return _normalization_multiplier;
     }
 
     bool useDPOrientation( ) const {
@@ -148,6 +153,13 @@ private:
      * Default is the OpenCV method.
      */
     bool _use_root_sift;
+
+    /* SIFT descriptors are normalized in a final step.
+     * The values of the descriptor can also be multiplied
+     * by a power of 2 if required.
+     * Specify the exponent.
+     */
+    int      _normalization_multiplier;
 
     /* Call the debug functions in gauss_filter.cu to print Gauss
      * filter width and Gauss tables in use.

--- a/src/popsift/sift_constants.cu
+++ b/src/popsift/sift_constants.cu
@@ -15,7 +15,7 @@ namespace popsift {
 ConstInfo                         h_consts;
 __device__ __constant__ ConstInfo d_consts;
 
-void init_constants( float sigma0, int levels, float threshold, float edge_limit, int max_extrema )
+void init_constants( float sigma0, int levels, float threshold, float edge_limit, int max_extrema, int normalization_multiplier )
 {
     cudaError_t err;
 
@@ -25,6 +25,7 @@ void init_constants( float sigma0, int levels, float threshold, float edge_limit
     h_consts.threshold    = threshold;
     h_consts.extrema      = max_extrema;
     h_consts.orientations = max_extrema + max_extrema/4;
+    h_consts.norm_multi   = normalization_multiplier;
 
     err = cudaMemcpyToSymbol( d_consts, &h_consts,
                               sizeof(ConstInfo), 0,

--- a/src/popsift/sift_constants.h
+++ b/src/popsift/sift_constants.h
@@ -55,12 +55,13 @@ struct ConstInfo
     float sigma_k;
     float edge_limit;
     float threshold;
+    int   norm_multi;
 };
 
 extern                         ConstInfo h_consts;
 extern __device__ __constant__ ConstInfo d_consts;
 
 
-void init_constants( float sigma0, int levels, float threshold, float edge_limit, int max_extrema );
+void init_constants( float sigma0, int levels, float threshold, float edge_limit, int max_extrema, int normalization_multiplier );
 
 } // namespace popsift


### PR DESCRIPTION
Added a multiplier that can be applied after normalization, normally to help the conversion of float features in [0 1] to uchar features between [0 256].
- the multiplier can be only a power of 2 (performance reasons)
