### PR TITLE
Modern cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,11 @@ before_script:
   - cd $POPSIFT_BUILD
   # Classic release build
   - >
-     cmake . $POPSIFT_SOURCE
+     cmake . $POPSIFT_SOURCE -DCMAKE_INSTALL_PREFIX=`pwd`/install
 
 script:
 # limit GCC builds to a reduced number of thread for the virtual machine
-  - make -j 2 VERBOSE=1
+  - make install -j 2 VERBOSE=1
 # Perform unit tests
   # - make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ env:
     - BUILD_PROCESSOR="`uname -p`"
     - POPSIFT_SOURCE=${TRAVIS_BUILD_DIR}
     - POPSIFT_BUILD=${TRAVIS_BUILD_DIR}/build
+    - POPSIFT_INSTALL=${POPSIFT_BUILD}/install
+    - POPSIFT_APP_SRC=${POPSIFT_SOURCE}/src/application
+    - POPSIFT_APP_BUILD=${POPSIFT_APP_SRC}/build
+    - POPSIFT_APP_INSTALL=${POPSIFT_APP_BUILD}/install
     # CMAKE
     # - CMAKE_URL="https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.tar.gz"
     - CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"
@@ -62,13 +66,19 @@ before_script:
   - cd $POPSIFT_BUILD
   # Classic release build
   - >
-     cmake . $POPSIFT_SOURCE -DCMAKE_INSTALL_PREFIX=`pwd`/install
+     cmake . $POPSIFT_SOURCE -DCMAKE_INSTALL_PREFIX=$POPSIFT_INSTALL
 
 script:
 # limit GCC builds to a reduced number of thread for the virtual machine
   - make install -j 2 VERBOSE=1
 # Perform unit tests
   # - make test
+# Perform tests building application with PopSift as 3rd party
+  - cd $POPSIFT_APP_SRC
+  - mkdir POPSIFT_APP_BUILD
+  - cd POPSIFT_APP_BUILD
+  - cmake .. -DPopSift_DIR=$POPSIFT_INSTALL/lib/cmake/PopSift/ -DCMAKE_INSTALL_PREFIX=$POPSIFT_APP_INSTALL
+  - make install -j 2 VERBOSE=1
 
 cache:
   directories:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMake below 3.4 does not work with CUDA separable compilation at all
-CMAKE_MINIMUM_REQUIRED(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4)
 
-PROJECT( PopSift )
+project( PopSift )
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
@@ -25,37 +25,37 @@ endif(Boost_FOUND)
 
 find_package(CUDA 7.0)
 
-IF(CUDA_FOUND)
-  SET(CUDA_SEPARABLE_COMPILATION ON)
-  include_directories(${CUDA_INCLUDE_DIRS})
-
-  set(CUDA_NVCC_FLAGS_DEBUG   "${CUDA_NVCC_FLAGS_DEBUG};-G;-g")
-  set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-O3")
-  set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_30,code=sm_30")
-  set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_35,code=sm_35")
-  set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_50,code=sm_50")
-  set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_52,code=sm_52")
-  set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_52,code=compute_52")
-  # default stream legacy implies that the 0 stream synchronizes all streams
-  set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};--default-stream;legacy")
-  # default stream per-thread implies that each host thread has one non-synchronizing 0-stream
-  # set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};--default-stream;per-thread")
-  # print local memory usage per kernel: -Xptxas;-v
-  # CUDA >= 7.5: -Xptxas;--warn-on-local-memory-usage;-Xptxas;--warn-on-spills
-  message(STATUS "CUDA Version is ${CUDA_VERSION}")
-  if(CUDA_VERSION>=7.5)
-    set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-Xptxas;--warn-on-local-memory-usage")
-    set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-Xptxas;--warn-on-spills")
-  else(CUDA_VERSION>=7.5)
-  endif(CUDA_VERSION>=7.5)
-
-  # library required for CUDA dynamic parallelism, forgotten by CMake 3.4
-  cuda_find_library_local_first(CUDA_CUDADEVRT_LIBRARY cudadevrt "\"cudadevrt\" library")
-
-  include_directories("${CMAKE_SOURCE_DIR}/popsift/Cuda-7.0-cub")
-ELSE(CUDA_FOUND)
+if(NOT CUDA_FOUND)
   message( FATAL_ERROR "Could not find CUDA >= 7.0" )
-ENDIF(CUDA_FOUND)
+endif()
+
+set(CUDA_SEPARABLE_COMPILATION ON)
+include_directories(${CUDA_INCLUDE_DIRS})
+
+set(CUDA_NVCC_FLAGS_DEBUG   "${CUDA_NVCC_FLAGS_DEBUG};-G;-g")
+set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-O3")
+set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_30,code=sm_30")
+set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_35,code=sm_35")
+set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_50,code=sm_50")
+set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_52,code=sm_52")
+set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_52,code=compute_52")
+# default stream legacy implies that the 0 stream synchronizes all streams
+set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};--default-stream;legacy")
+# default stream per-thread implies that each host thread has one non-synchronizing 0-stream
+# set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};--default-stream;per-thread")
+# print local memory usage per kernel: -Xptxas;-v
+# CUDA >= 7.5: -Xptxas;--warn-on-local-memory-usage;-Xptxas;--warn-on-spills
+message(STATUS "CUDA Version is ${CUDA_VERSION}")
+if(CUDA_VERSION>=7.5)
+  set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-Xptxas;--warn-on-local-memory-usage")
+  set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-Xptxas;--warn-on-spills")
+else(CUDA_VERSION>=7.5)
+endif(CUDA_VERSION>=7.5)
+
+# library required for CUDA dynamic parallelism, forgotten by CMake 3.4
+cuda_find_library_local_first(CUDA_CUDADEVRT_LIBRARY cudadevrt "\"cudadevrt\" library")
+
+include_directories("${CMAKE_SOURCE_DIR}/popsift/Cuda-7.0-cub")
 
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMake below 3.4 does not work with CUDA separable compilation at all
 cmake_minimum_required(VERSION 3.4)
 
-project( PopSift )
+project(PopSift VERSION 1.0.0)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,19 +5,25 @@ project(PopSift VERSION 1.0.0)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
-set(CMAKE_BUILD_TYPE Release) # Debug, Release
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+  message(STATUS "Build type not set, building in Release configuration")
+else()
+  message(STATUS "Building in ${CMAKE_BUILD_TYPE} configuration")
+endif()
 
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_DEBUG} -O3")
 set(CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_DEBUG}   -O3")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DGRIFF_DEBUG")
-set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG}   -DGRIFF_DEBUG")
+
+#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DGRIFF_DEBUG")
+#set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG}   -DGRIFF_DEBUG")
 
 find_package(Boost 1.53.0 REQUIRED COMPONENTS system filesystem)
 
 find_package(CUDA 7.0)
 
 if(NOT CUDA_FOUND)
-  message( FATAL_ERROR "Could not find CUDA >= 7.0" )
+  message(FATAL_ERROR "Could not find CUDA >= 7.0")
 endif()
 
 set(CUDA_SEPARABLE_COMPILATION ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(CUDA 7.0)
 IF(CUDA_FOUND)
   SET(CUDA_SEPARABLE_COMPILATION ON)
   include_directories(${CUDA_INCLUDE_DIRS})
-  add_definitions("-DWITH_CUDA")
+
   set(CUDA_NVCC_FLAGS_DEBUG   "${CUDA_NVCC_FLAGS_DEBUG};-G;-g")
   set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-O3")
   set(CUDA_NVCC_FLAGS         "${CUDA_NVCC_FLAGS};-gencode;arch=compute_30,code=sm_30")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,15 +14,6 @@ set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG}   -DGRIFF_DEBUG")
 
 find_package(Boost 1.53.0 REQUIRED COMPONENTS system filesystem)
 
-if(Boost_FOUND)
-  include_directories(${Boost_INCLUDE_DIRS})
-  # link_directories(${Boost_LIB_DIR})
-  add_definitions(${Boost_DEFINITIONS})
-  message( STATUS "Found BOOST: ${Boost_LIBRARIES}" )
-else(Boost_FOUND)
-  message( FATAL_ERROR "Boost not found" )
-endif(Boost_FOUND)
-
 find_package(CUDA 7.0)
 
 if(NOT CUDA_FOUND)
@@ -30,7 +21,6 @@ if(NOT CUDA_FOUND)
 endif()
 
 set(CUDA_SEPARABLE_COMPILATION ON)
-include_directories(${CUDA_INCLUDE_DIRS})
 
 set(CUDA_NVCC_FLAGS_DEBUG   "${CUDA_NVCC_FLAGS_DEBUG};-G;-g")
 set(CUDA_NVCC_FLAGS_RELEASE "${CUDA_NVCC_FLAGS_RELEASE};-O3")
@@ -55,7 +45,6 @@ endif(CUDA_VERSION>=7.5)
 # library required for CUDA dynamic parallelism, forgotten by CMake 3.4
 cuda_find_library_local_first(CUDA_CUDADEVRT_LIBRARY cudadevrt "\"cudadevrt\" library")
 
-include_directories("${CMAKE_SOURCE_DIR}/popsift/Cuda-7.0-cub")
 
 add_subdirectory(src)
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Continuous integration:
 - [![Build Status](https://travis-ci.org/poparteu/popsift.svg?branch=develop)](https://travis-ci.org/poparteu/popsift) develop branch.
 
 
+
 Usage
 -----
 
@@ -36,7 +37,7 @@ To integrate PopSift into other software, link with `libpopsift`.  If your are u
 ```cmake
 # Find the package from the PopSiftConfig.cmake 
 # in <prefix>/lib/cmake/PopSift/. Under the namespace PopSift::
-# it expose the target popsift that allows you to compile
+# it exposes the target popsift that allows you to compile
 # and link with the library
 find_package(PopSift CONFIG REQUIRED)
 ...
@@ -45,6 +46,14 @@ add_executable(poptest yourfile.cpp)
 # add link to the library
 target_link_libraries(poptest PUBLIC PopSift::popsift)
 ```
+
+Then, in order to build just pass the location of `PopSiftConfig.cmake` from the cmake command line:
+
+```bash
+cmake .. -DPopSift_DIR=<prefix>/lib/cmake/PopSift/
+```
+
+
 
 ### Calling the API
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
+
 PopSift
 =======
 
 PopSift is an implementation of the SIFT algorithm in CUDA.
 PopSift tries to stick as closely as possible to David Lowe's famous paper (Lowe, D. G. (2004). Distinctive Image Features from Scale-Invariant Keypoints. International Journal of Computer Vision, 60(2), 91–110. doi:10.1023/B:VISI.0000029664.99615.94), while extracting features from an image in real-time at least on an NVidia GTX 980 Ti GPU.
+
 
 Build
 -----
@@ -18,23 +20,45 @@ make install
 ```
 
 Continuous integration: 
- - [![Build Status](https://travis-ci.org/poparteu/popsift.svg?branch=master)](https://travis-ci.org/poparteu/popsift) master branch.
- - [![Build Status](https://travis-ci.org/poparteu/popsift.svg?branch=develop)](https://travis-ci.org/poparteu/popsift) develop branch.
+- [![Build Status](https://travis-ci.org/poparteu/popsift.svg?branch=master)](https://travis-ci.org/poparteu/popsift) master branch.
+- [![Build Status](https://travis-ci.org/poparteu/popsift.svg?branch=develop)](https://travis-ci.org/poparteu/popsift) develop branch.
+
 
 Usage
 -----
 
-Two artifacts are made: libpopsift and the test application popsift-demo. Calling popsift-demo without parameters shows an option.
+Two artifacts are made: `libpopsift` and the test application `popsift-demo`. Calling popsift-demo without parameters shows the options.
 
-To integrate PopSift into other software, link with libpopsift.  The caller must create a popart::Config struct (documented in src/sift/sift_conf.h) to control the behaviour of the PopSift, and instantiate an object of class PopSift (found in src/sift/popsift.h).  After creating an instance, it must be configured to the constant width and height of the input image (init()).  After that, it can be fed a one image at a time (execute()). The only valid input format is a single plane of grayscale unsigned characters. The execute() function returns a pointer to an object of type Features that must be deleted by the caller after use. Features offer iterators that iterate over objects of type Feature. Both classes are documented in sift_extremum.h. Each feature represents a feature point in the coordinate system of the input image, providing X and Y coordinates and scale (sigma), as well as several alternative descriptors for the feature point (according to Lowe, 15% of the feature points should be expected to have 2 or more descriptors).
+### Using PopSift as third party
+
+To integrate PopSift into other software, link with `libpopsift`.  If your are using CMake for building your project you can easily add PopSift to your project. Once you have built and installed PopSift in a directory (say, `<prefix>`), in your `CMakeLists.txt` file just add the dependency
+
+```cmake
+# Find the package from the PopSiftConfig.cmake 
+# in <prefix>/lib/cmake/PopSift/. Under the namespace PopSift::
+# it expose the target popsift that allows you to compile
+# and link with the library
+find_package(PopSift CONFIG REQUIRED)
+...
+# suppose you want to try it out in a executable
+add_executable(poptest yourfile.cpp)
+# add link to the library
+target_link_libraries(poptest PUBLIC PopSift::popsift)
+```
+
+### Calling the API
+
+The caller must create a `popart::Config` struct (documented in `src/sift/sift_conf.h`) to control the behaviour of the PopSift, and instantiate an object of class `PopSift` (found in `src/sift/popsift.h`).  After creating an instance, it must be configured to the constant width and height of the input image (`init()`).  After that, it can be fed a one image at a time (`execute()`). The only valid input format is a single plane of grayscale unsigned characters. The `execute()` function returns a pointer to an object of type `Features` that must be deleted by the caller after use. Features offer iterators that iterate over objects of type `Feature`. Both classes are documented in `sift_extremum.h`. Each feature represents a feature point in the coordinate system of the input image, providing X and Y coordinates and scale (sigma), as well as several alternative descriptors for the feature point (according to Lowe, 15% of the feature points should be expected to have 2 or more descriptors).
 
 As far as we know, no implementation that is faster than PopSift at the time of PopSift's release comes under a license that allows commercial use and sticks close to the original paper at the same time as well. PopSift can be configured at runtime to use constants that affect it behaviours. In particular, users can choose to generate results very similar to VLFeat or results that are closer (but not as close) to the SIFT implementation of the OpenCV extras. We acknowledge that there is at least one SIFT implementation that is vastly faster, but it makes considerable sacifices in terms of accuracy and compatibility.
+
 
 License
 -------
 
 PopSift is licensed under [MPL v2 license](LICENSE.md).
 However, SIFT is patented in the US and perhaps other countries, and this license does not release users of this code from any requirements that may arise from such patents.
+
 
 Authors
 -------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,13 +24,65 @@ set_property(TARGET popsift PROPERTY VERSION ${PROJECT_VERSION})
 # cannot use PRIVATE here as there is a bug in FindCUDA 
 # https://gitlab.kitware.com/cmake/cmake/issues/16097
 target_link_libraries(popsift ${Boost_LIBRARIES} ${CUDA_CUDADEVRT_LIBRARY})
+
 add_subdirectory(application)
 
-install(TARGETS popsift DESTINATION lib EXPORT popsift-targets)
 
-INSTALL(
-  DIRECTORY popsift
-  DESTINATION include
-  COMPONENT headers
-  FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h"
-)
+# EXPORTING THE LIBRARY
+#
+# place to put the cmake-related files
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+# include directory for install
+set(include_install_dir "include")
+
+# build directory containing the generated files
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Note: major version number must be the same as requested
+write_basic_package_version_file("${version_config}" COMPATIBILITY SameMajorVersion)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * targets_export_name
+#   * PROJECT_NAME
+configure_package_config_file("cmake/Config.cmake.in"
+                              "${project_config}"
+                              INSTALL_DESTINATION "${config_install_dir}")
+
+# Targets:
+#   * <prefix>/lib/libpopsift.a
+#   * header location after install: <prefix>/include/
+#   * headers can be included by C++ code `#include <popsift/popsift.h>`
+install(TARGETS popsift
+        EXPORT "${targets_export_name}"
+        LIBRARY DESTINATION "lib"
+        ARCHIVE DESTINATION "lib"
+        RUNTIME DESTINATION "bin"
+        INCLUDES DESTINATION "${include_install_dir}")
+
+# Headers:
+install(DIRECTORY "popsift"
+        DESTINATION "${include_install_dir}"
+        FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h")
+
+# Config
+#   * <prefix>/lib/cmake/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake
+#   * <prefix>/lib/cmake/${PROJECT_NAME}${PROJECT_NAME}ConfigVersion.cmake
+install(FILES "${project_config}" "${version_config}"
+        DESTINATION "${config_install_dir}")
+
+# Config
+#   * <prefix>/lib/cmake/${PROJECT_NAME}/${PROJECT_NAME}Targets.cmake
+install(EXPORT "${targets_export_name}"
+        NAMESPACE "${namespace}"
+        DESTINATION "${config_install_dir}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,13 +8,22 @@ FILE( GLOB_RECURSE
 
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR})
 
-include_directories(${CMAKE_SOURCE_DIR}/src/common)
 
-CUDA_ADD_LIBRARY( popsift STATIC
+CUDA_ADD_LIBRARY(popsift STATIC
                   ${src_files_cu}
-		  ${src_files_cpp} )
+		  ${src_files_cpp})
+
+target_include_directories(popsift 
+            PRIVATE ${Boost_INCLUDE_DIRS}
+            PUBLIC ${CUDA_INCLUDE_DIRS})
+
+target_compile_definitions(popsift PRIVATE ${Boost_DEFINITIONS})
+
 set_property(TARGET popsift PROPERTY VERSION ${PROJECT_VERSION})
 
+# cannot use PRIVATE here as there is a bug in FindCUDA 
+# https://gitlab.kitware.com/cmake/cmake/issues/16097
+target_link_libraries(popsift ${Boost_LIBRARIES} ${CUDA_CUDADEVRT_LIBRARY})
 add_subdirectory(application)
 
 install(TARGETS popsift DESTINATION lib EXPORT popsift-targets)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src/common)
 CUDA_ADD_LIBRARY( popsift STATIC
                   ${src_files_cu}
 		  ${src_files_cpp} )
+set_property(TARGET popsift PROPERTY VERSION ${PROJECT_VERSION})
 
 add_subdirectory(application)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,9 +13,12 @@ CUDA_ADD_LIBRARY(popsift STATIC
                  ${src_files_cu}
                  ${src_files_cpp})
 
+# BUILD_INTERFACE allows to include the directory with source only when target is
+# built in the building tree (ie, not from an install location)
 target_include_directories(popsift 
             PRIVATE ${Boost_INCLUDE_DIRS}
-            PUBLIC ${CUDA_INCLUDE_DIRS})
+            PUBLIC ${CUDA_INCLUDE_DIRS}
+            "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>")
 
 target_compile_definitions(popsift PRIVATE ${Boost_DEFINITIONS})
 
@@ -25,8 +28,6 @@ set_target_properties(popsift PROPERTIES DEBUG_POSTFIX "d")
 # cannot use PRIVATE here as there is a bug in FindCUDA and CUDA_ADD_LIBRARY
 # https://gitlab.kitware.com/cmake/cmake/issues/16097
 target_link_libraries(popsift ${Boost_LIBRARIES} ${CUDA_CUDADEVRT_LIBRARY})
-
-add_subdirectory(application)
 
 
 # EXPORTING THE LIBRARY
@@ -87,3 +88,6 @@ install(FILES "${project_config}" "${version_config}"
 install(EXPORT "${targets_export_name}"
         NAMESPACE "${namespace}"
         DESTINATION "${config_install_dir}")
+
+
+add_subdirectory(application)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,8 +10,8 @@ set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR})
 
 
 CUDA_ADD_LIBRARY(popsift STATIC
-                  ${src_files_cu}
-		  ${src_files_cpp})
+                 ${src_files_cu}
+                 ${src_files_cpp})
 
 target_include_directories(popsift 
             PRIVATE ${Boost_INCLUDE_DIRS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,9 +19,10 @@ target_include_directories(popsift
 
 target_compile_definitions(popsift PRIVATE ${Boost_DEFINITIONS})
 
-set_property(TARGET popsift PROPERTY VERSION ${PROJECT_VERSION})
+set_target_properties(popsift PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(popsift PROPERTIES DEBUG_POSTFIX "d")
 
-# cannot use PRIVATE here as there is a bug in FindCUDA 
+# cannot use PRIVATE here as there is a bug in FindCUDA and CUDA_ADD_LIBRARY
 # https://gitlab.kitware.com/cmake/cmake/issues/16097
 target_link_libraries(popsift ${Boost_LIBRARIES} ${CUDA_CUDADEVRT_LIBRARY})
 

--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -2,14 +2,13 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR})
 
 add_executable(popsift-demo main.cpp pgmread.cpp )
 
-target_include_directories( popsift-demo PRIVATE
-                            ${CMAKE_SOURCE_DIR}/src
-                            )
+target_include_directories(popsift-demo PRIVATE
+                           ${CMAKE_SOURCE_DIR}/src)
 
-target_link_libraries( popsift-demo popsift
-                               ${CUDA_LIBRARIES}
-			       ${CUDA_CUDADEVRT_LIBRARY}
-			       ${Boost_LIBRARIES} )
+target_link_libraries(popsift-demo popsift
+                      ${CUDA_LIBRARIES}
+                      ${CUDA_CUDADEVRT_LIBRARY}
+                      ${Boost_LIBRARIES} )
 
 install(TARGETS popsift-demo DESTINATION bin EXPORT popsift-targets)
 

--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -3,6 +3,7 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR})
 add_executable(popsift-demo main.cpp pgmread.cpp )
 
 target_include_directories(popsift-demo PRIVATE
+                           ${Boost_INCLUDE_DIRS}
                            ${CMAKE_SOURCE_DIR}/src)
 
 target_link_libraries(popsift-demo popsift

--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -1,15 +1,25 @@
+cmake_minimum_required(VERSION 3.0)
+project(PopsiftDemo)
+
+if(TARGET popsift)
+  # when compiled in the repository the target is already defined
+  add_library(PopSift::popsift ALIAS popsift)
+else()
+  # Add NO_CMAKE_BUILDS_PATH for windows if using CMake-GUI to build packages
+  # to avoid searching in temporary build directory of Foo project
+  # See 5:
+  #    * http://www.cmake.org/cmake/help/v3.0/command/find_package.html
+  find_package(PopSift CONFIG REQUIRED)
+endif()
+
+find_package(Boost 1.53.0 REQUIRED COMPONENTS filesystem)
+
+add_executable(popsift-demo main.cpp pgmread.cpp)
+
+target_include_directories(popsift-demo PUBLIC ${Boost_INCLUDE_DIRS})
+
+target_link_libraries(popsift-demo PUBLIC PopSift::popsift ${Boost_LIBRARIES})
+
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR})
 
-add_executable(popsift-demo main.cpp pgmread.cpp )
-
-target_include_directories(popsift-demo PRIVATE
-                           ${Boost_INCLUDE_DIRS}
-                           ${CMAKE_SOURCE_DIR}/src)
-
-target_link_libraries(popsift-demo popsift
-                      ${CUDA_LIBRARIES}
-                      ${CUDA_CUDADEVRT_LIBRARY}
-                      ${Boost_LIBRARIES} )
-
-install(TARGETS popsift-demo DESTINATION bin EXPORT popsift-targets)
-
+install(TARGETS popsift-demo DESTINATION bin)

--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR})
 
-add_executable( popsift-demo main.cpp pgmread.cpp pgmread.h )
+add_executable(popsift-demo main.cpp pgmread.cpp )
 
 target_include_directories( popsift-demo PRIVATE
                             ${CMAKE_SOURCE_DIR}/src

--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -1,3 +1,42 @@
+################################################################################
+#
+# PopSift - a CUDA implementation of the SIFT algorithm
+#
+# Copyright 2016, Simula Research Laboratory
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+# Config file for PopSift.
+#
+# This file is used by CMake when find_package(PopSift) is invoked and either
+# the directory containing this file either is present in CMAKE_MODULE_PATH
+# (if PopSift was installed), or exists in the local CMake package registry if
+# the PopSift build directory was exported.
+#
+# This module defines a namespace PopSift:: and the target needed to compile and
+# link against the library. The target automatically propagate the dependencies
+# of the library.
+#
+# In your CMakeLists.txt  file just add the dependency
+#
+# find_package(PopSift CONFIG REQUIRED)
+#
+# Then if you want to link it to an executable
+#
+# add_executable(poptest yourfile.cpp)
+#
+# Then to the library
+#
+# target_link_libraries(poptest PUBLIC PopSift::popsift)
+#
+# Note that target_include_directories() is not necessary.
+#
+################################################################################
+
+
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")


### PR DESCRIPTION
Allows to include PopSift in other cmake-based project by using the proper config file. Also some clean up and using modern cmake syntax.

connected to #13 