### PR TITLE
Fix Windows build

### DIFF
--- a/src/popsift/features.cu
+++ b/src/popsift/features.cu
@@ -7,10 +7,7 @@
  */
 #include <iomanip>
 #include <iostream>
-#include <unistd.h>
-#ifndef __APPLE__
-#include <malloc.h>
-#endif
+
 #include <stdlib.h>
 #include <errno.h>
 #include <math_constants.h>
@@ -58,25 +55,12 @@ FeaturesHost::~FeaturesHost( )
     free( _ori );
 }
 
-#ifdef __APPLE__
-static void* memalign( size_t alignment, size_t size )
-{
-    void* ret;
-    int err = posix_memalign( &ret, alignment, size );
-    if( err != 0 ) {
-        errno = err;
-        ret = 0;
-    }
-    return ret;
-}
-#endif
-
 void FeaturesHost::reset( int num_ext, int num_ori )
 {
     if( _ext != 0 ) { free( _ext ); _ext = 0; }
     if( _ori != 0 ) { free( _ori ); _ori = 0; }
 
-    _ext = (Feature*)memalign( sysconf(_SC_PAGESIZE), num_ext * sizeof(Feature) );
+    _ext = (Feature*)memalign( getPageSize(), num_ext * sizeof(Feature) );
     if( _ext == 0 ) {
         cerr << __FILE__ << ":" << __LINE__ << " Runtime error:" << endl
              << "    Failed to (re)allocate memory for downloading " << num_ext << " features" << endl;
@@ -84,7 +68,7 @@ void FeaturesHost::reset( int num_ext, int num_ori )
         if( errno == ENOMEM ) cerr << "    Not enough memory." << endl;
         exit( -1 );
     }
-    _ori = (Descriptor*)memalign( sysconf(_SC_PAGESIZE), num_ori * sizeof(Descriptor) );
+    _ori = (Descriptor*)memalign( getPageSize(), num_ori * sizeof(Descriptor) );
     if( _ori == 0 ) {
         cerr << __FILE__ << ":" << __LINE__ << " Runtime error:" << endl
              << "    Failed to (re)allocate memory for downloading " << num_ori << " descriptors" << endl;

--- a/src/popsift/popsift.cu
+++ b/src/popsift/popsift.cu
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 #include <fstream>
-#include <pthread.h> // for pthread_self
 
 #include "sift_constants.h"
 #include "popsift.h"

--- a/src/popsift/s_desc_notile.cu
+++ b/src/popsift/s_desc_notile.cu
@@ -25,6 +25,7 @@
 
 using namespace popsift;
 
+__device__
 static const float stepbase =  - 2.5f + 1.0f / 16.0f;
 
 __device__ static inline

--- a/src/popsift/sift_conf.h
+++ b/src/popsift/sift_conf.h
@@ -15,6 +15,13 @@
 
 #undef USE_DOG_TEX_LINEAR
 
+#ifdef _MSC_VER
+#define DEPRECATED(func) __declspec(deprecated) func
+#elif defined(__GNUC__) || defined(__clang__)
+#define DEPRECATED(func) func __attribute__ ((deprecated))
+#else
+#endif
+
 namespace popsift
 {
 
@@ -158,8 +165,7 @@ struct Config
      */
     void               setNormMode( NormMode m );
     void               setNormMode( const std::string& m );
-    void               setNormNode( const std::string& m );
-    void               setUseRootSift( bool on ) __attribute__ ((deprecated));
+    DEPRECATED(void    setUseRootSift( bool on ));
     bool               getUseRootSift( ) const;
     NormMode           getNormMode( NormMode m ) const;
     static NormMode    getNormModeDefault( ); // Call this from the constructor.


### PR DESCRIPTION
Remove Unix-only includes/directives and centralize cross-platform functions to fix build on Windows platform.