### PR TITLE
fix missing header windows

### DIFF
--- a/src/popsift/common/assist.h
+++ b/src/popsift/common/assist.h
@@ -9,11 +9,11 @@
 
 #include <cuda_runtime.h>
 #include <iostream>
+#include <thread>
 #ifdef _WIN32
 #include <windows.h>
 #else
 #include <unistd.h>
-#include <thread>
 #endif
 
 #include "sift_config.h"


### PR DESCRIPTION
`thread` was not included in the windows version, sorry