### PR TITLE
[bugfix] remove using std to avoid collision

### DIFF
--- a/src/popsift/s_filtergrid.cu
+++ b/src/popsift/s_filtergrid.cu
@@ -16,8 +16,6 @@
 #define nvtxRangePop()
 #endif
 
-using namespace std;
-
 #if not POPSIFT_IS_DEFINED(POPSIFT_DISABLE_GRID_FILTER)
 
 #include <thrust/device_vector.h>


### PR DESCRIPTION
Tiny fix for a namespace collision between CUDA isinf and std::isinf that is due to the "using namespace std" statement