### PR TITLE
[docker] add support for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommend
         libboost-filesystem-dev \
         libboost-system-dev \
         libboost-program-options-dev \
-        libboost-thread-dev
+        libboost-thread-dev \
+ && rm -rf /var/lib/apt/lists/*
 
 ADD . /opt/popsift
 RUN cd /opt/popsift && mkdir build && cd build && cmake .. && make install -j8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
+# use CUDA_TAG to select the image version to use
+# see https://hub.docker.com/r/nvidia/cuda/
+#
+# For example to create a ubuntu 16.04 with cuda 8.0 for development, use
+# docker build --build-arg CUDA_TAG=8.0-devel --tag popsift .
+#
+# then execute wiht nvidia docker (https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0))
+# docker run -it --runtime=nvidia popsift
+
 ARG CUDA_TAG=9.2-devel
 FROM nvidia/cuda:$CUDA_TAG
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM nvidia/cuda:$CUDA_TAG
 # Cuda version (ENV): $CUDA_VERSION
 
 # System update
-RUN apt-get clean && apt-get update && apt-get install -y \
+RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommends\
 				build-essential \
 				cmake \
 				git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,5 @@ RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommend
         libboost-thread-dev \
  && rm -rf /var/lib/apt/lists/*
 
-ADD . /opt/popsift
 RUN cd /opt/popsift && mkdir build && cd build && cmake .. && make install -j8
+COPY . /opt/popsift

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,18 +17,18 @@ LABEL maintainer="AliceVision Team alicevision@googlegroups.com"
 
 # System update
 RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommends\
-				build-essential \
-				cmake \
-				git \
-				wget \
-				unzip \
-				yasm \
-				pkg-config \
-				libtool \
-				nasm \
-				automake \
-				libpng12-dev \
-				libjpeg-turbo8-dev \
+        build-essential \
+        cmake \
+        git \
+        wget \
+        unzip \
+        yasm \
+        pkg-config \
+        libtool \
+        nasm \
+        automake \
+        libpng12-dev \
+        libjpeg-turbo8-dev \
         libdevil-dev \
         libboost-filesystem-dev \
         libboost-system-dev \
@@ -37,5 +37,5 @@ RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommend
  && rm -rf /var/lib/apt/lists/*
 
 COPY . /opt/popsift
-WORKDIR /opt/popsift
-RUN mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release && make install -j
+WORKDIR /opt/popsift/build
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release && make install -j

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@
 ARG CUDA_TAG=9.2-devel
 FROM nvidia/cuda:$CUDA_TAG
 
-ARG		PYTHON
-
 # OS/Version (FILE): cat /etc/issue.net
 # Cuda version (ENV): $CUDA_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+ARG CUDA_TAG=9.2-devel
+FROM nvidia/cuda:$CUDA_TAG
+LABEL maintainer="AliceVision Team alicevision@googlegroups.com"
+
 # use CUDA_TAG to select the image version to use
 # see https://hub.docker.com/r/nvidia/cuda/
 #
@@ -7,9 +11,6 @@
 # then execute with nvidia docker (https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0))
 # docker run -it --runtime=nvidia popsift
 
-LABEL maintainer="AliceVision Team alicevision@googlegroups.com"
-ARG CUDA_TAG=9.2-devel
-FROM nvidia/cuda:$CUDA_TAG
 
 # OS/Version (FILE): cat /etc/issue.net
 # Cuda version (ENV): $CUDA_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommend
 
 COPY . /opt/popsift
 WORKDIR /opt/popsift
-RUN mkdir build && cd build && cmake .. && make install -j
+RUN mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release && make install -j

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+ARG CUDA_TAG=9.2-devel
+FROM nvidia/cuda:$CUDA_TAG
+
+ARG		PYTHON
+
+# OS/Version (FILE): cat /etc/issue.net
+# Cuda version (ENV): $CUDA_VERSION
+
+# System update
+RUN apt-get clean && apt-get update && apt-get install -y \
+				build-essential \
+				cmake \
+				git \
+				wget \
+				unzip \
+				yasm \
+				pkg-config \
+				libtool \
+				nasm \
+				automake \
+				libpng12-dev \
+				libjpeg-turbo8-dev \
+        libdevil-dev \
+        libboost-filesystem-dev \
+        libboost-system-dev \
+        libboost-program-options-dev \
+        libboost-thread-dev
+
+ADD . /opt/popsift
+RUN cd /opt/popsift && mkdir build && cd build && cmake .. && make install -j8

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@
 # then execute with nvidia docker (https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0))
 # docker run -it --runtime=nvidia popsift
 
+LABEL maintainer="AliceVision Team alicevision@googlegroups.com"
 ARG CUDA_TAG=9.2-devel
 FROM nvidia/cuda:$CUDA_TAG
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # use CUDA_TAG to select the image version to use
 # see https://hub.docker.com/r/nvidia/cuda/
 #
-# For example to create a ubuntu 16.04 with cuda 8.0 for development, use
+# For example, to create a ubuntu 16.04 with cuda 8.0 for development, use
 # docker build --build-arg CUDA_TAG=8.0-devel --tag popsift .
 #
-# then execute wiht nvidia docker (https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0))
+# then execute with nvidia docker (https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0))
 # docker run -it --runtime=nvidia popsift
 
 ARG CUDA_TAG=9.2-devel

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,6 @@ RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommend
         libboost-thread-dev \
  && rm -rf /var/lib/apt/lists/*
 
-RUN cd /opt/popsift && mkdir build && cd build && cmake .. && make install -j8
 COPY . /opt/popsift
+WORKDIR /opt/popsift
+RUN mkdir build && cd build && cmake .. && make install -j


### PR DESCRIPTION
Support for docker.

It is based on nvidia/cuda image (https://hub.docker.com/r/nvidia/cuda/)

A parameter `CUDA_TAG` can be passed when building the image to select the ubuntu and cuda version. 
For example to create a ubuntu 16.04 with cuda 8.0 for development, use
```
docker build --build-arg CUDA_TAG=8.0-devel --tag popsift .
```

In order to run the image nvidia docker is needed https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)
```
docker run -it --runtime=nvidia popsift
```