### PR TITLE
Update Plane2D step after resetDimensions

### DIFF
--- a/src/popsift/s_image.cu
+++ b/src/popsift/s_image.cu
@@ -159,7 +159,7 @@ void Image::createTexture( )
     _input_image_resDesc.res.pitch2D.desc.z       = 0;
     _input_image_resDesc.res.pitch2D.desc.w       = 0;
     assert( _input_image_d.elemSize() == 1 );
-    _input_image_resDesc.res.pitch2D.pitchInBytes = _input_image_d.step;
+    _input_image_resDesc.res.pitch2D.pitchInBytes = _input_image_d.getPitchInBytes();
     _input_image_resDesc.res.pitch2D.width        = _input_image_d.getCols();
     _input_image_resDesc.res.pitch2D.height       = _input_image_d.getRows();
 
@@ -283,7 +283,7 @@ void ImageFloat::createTexture( )
     _input_image_resDesc.res.pitch2D.desc.z       = 0;
     _input_image_resDesc.res.pitch2D.desc.w       = 0;
     assert( _input_image_d.elemSize() == 4 );
-    _input_image_resDesc.res.pitch2D.pitchInBytes = _input_image_d.step; /* the step in Plane2D is in bytes */
+    _input_image_resDesc.res.pitch2D.pitchInBytes = _input_image_d.getPitchInBytes();
     _input_image_resDesc.res.pitch2D.width        = _input_image_d.getCols();
     _input_image_resDesc.res.pitch2D.height       = _input_image_d.getRows();
 

--- a/src/popsift/s_image.cu
+++ b/src/popsift/s_image.cu
@@ -74,7 +74,7 @@ void Image::load( void* input )
      * is in CUDA-allocated pinned host memory, which makes the H2D copy
      * much faster.
      */
-    memcpy( _input_image_h.data, input, _w*_h );
+    memcpy( _input_image_h.data, input, _w*_h ); // assume that host Plane2D has no pitch
     _input_image_h.memcpyToDevice( _input_image_d );
 }
 
@@ -94,8 +94,8 @@ void Image::resetDimensions( int w, int h )
     _h = h;
 
     if( w <= _max_w && h <= _max_h ) {
-        _input_image_h.resetDimensions( w, h );
-        _input_image_d.resetDimensions( w, h );
+        _input_image_h.resetDimensionsHost( w, h );
+        _input_image_d.resetDimensionsDev( w, h );
 
         destroyTexture( );
         createTexture( );
@@ -108,8 +108,8 @@ void Image::resetDimensions( int w, int h )
         _input_image_d.freeDev( );
         _input_image_h.allocHost( _max_w, _max_h, popsift::CudaAllocated );
         _input_image_d.allocDev(  _max_w, _max_h );
-        _input_image_h.resetDimensions( w, h );
-        _input_image_d.resetDimensions( w, h );
+        _input_image_h.resetDimensionsHost( w, h );
+        _input_image_d.resetDimensionsDev( w, h );
 
         destroyTexture( );
         createTexture( );
@@ -198,7 +198,7 @@ void ImageFloat::load( void* input )
      * is in CUDA-allocated pinned host memory, which makes the H2D copy
      * much faster.
      */
-    memcpy( _input_image_h.data, input, _w*_h*sizeof(float) );
+    memcpy( _input_image_h.data, input, _w*_h*sizeof(float) ); // assume that host Plane2D has no pitch
     _input_image_h.memcpyToDevice( _input_image_d );
 }
 
@@ -218,8 +218,8 @@ void ImageFloat::resetDimensions( int w, int h )
     _h = h;
 
     if( w <= _max_w && h <= _max_h ) {
-        _input_image_h.resetDimensions( w, h );
-        _input_image_d.resetDimensions( w, h );
+        _input_image_h.resetDimensionsHost( w, h );
+        _input_image_d.resetDimensionsDev( w, h );
 
         destroyTexture( );
         createTexture( );
@@ -232,8 +232,8 @@ void ImageFloat::resetDimensions( int w, int h )
         _input_image_d.freeDev( );
         _input_image_h.allocHost( _max_w, _max_h, popsift::CudaAllocated );
         _input_image_d.allocDev(  _max_w, _max_h );
-        _input_image_h.resetDimensions( w, h );
-        _input_image_d.resetDimensions( w, h );
+        _input_image_h.resetDimensionsHost( w, h );
+        _input_image_d.resetDimensionsDev( w, h );
 
         destroyTexture( );
         createTexture( );

--- a/src/popsift/s_image.h
+++ b/src/popsift/s_image.h
@@ -26,7 +26,7 @@ struct ImageBase
 
     virtual ~ImageBase( );
 
-    /** Reallocation that takes care of pitch/step when new dimensions
+    /** Reallocation that takes care of pitch when new dimensions
      *  are smaller and actually reallocation when they are bigger.
      */
     virtual void resetDimensions( int w, int h ) = 0;
@@ -76,7 +76,7 @@ struct Image : public ImageBase
 
     virtual ~Image( );
 
-    /** Reallocation that takes care of pitch/step when new dimensions
+    /** Reallocation that takes care of pitch when new dimensions
      *  are smaller and actually reallocation when they are bigger.
      */
     virtual void resetDimensions( int w, int h );
@@ -116,7 +116,7 @@ struct ImageFloat : public ImageBase
 
     virtual ~ImageFloat( );
 
-    /** Reallocation that takes care of pitch/step when new dimensions
+    /** Reallocation that takes care of pitch when new dimensions
      *  are smaller and actually reallocation when they are bigger.
      */
     virtual void resetDimensions( int w, int h );


### PR DESCRIPTION
Plane2D's step is directly related to effective width and needs to be updated when dimension changes.
This fixes an issue when mixing images with different resolutions that can result in wrong buffer accesses, as shown here:
![popsift_plane2D](https://user-images.githubusercontent.com/1674646/55020699-a8432580-4ff7-11e9-8ba8-39957a0f2008.jpg)
Re-using a previously allocated buffer (first figure) from the pool to work on another image with different width/height leads to erroneous results (second figure); updating the step fix this (third image).
Probably related to #56.