### PR TITLE
[cmake] fix for Boost 1.70

### DIFF
--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -15,6 +15,10 @@ endif()
 find_package(Boost 1.53.0 REQUIRED COMPONENTS program_options system filesystem)
 find_package(DevIL COMPONENTS IL ILU) # yields IL_FOUND, IL_LIBRARIES, IL_INCLUDE_DIR
 
+set(Boost_INCLUDE_DIRS "")
+set(Boost_LIBRARIES "")
+find_package(Boost 1.53.0 REQUIRED COMPONENTS filesystem program_options)
+
 set(PD_INCLUDE_DIRS    ${Boost_INCLUDE_DIRS})
 set(PD_LINK_LIBS       ${Boost_LIBRARIES} ${CUDA_CUDADEVRT_LIBRARY})
 

--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -12,7 +12,6 @@ else()
   find_package(PopSift CONFIG REQUIRED)
 endif()
 
-find_package(Boost 1.53.0 REQUIRED COMPONENTS program_options system filesystem)
 find_package(DevIL COMPONENTS IL ILU) # yields IL_FOUND, IL_LIBRARIES, IL_INCLUDE_DIR
 
 set(Boost_INCLUDE_DIRS "")

--- a/src/application/main.cpp
+++ b/src/application/main.cpp
@@ -304,10 +304,9 @@ int main(int argc, char **argv)
                      float_mode ? PopSift::FloatImages : PopSift::ByteImages );
 
     std::queue<SiftJob*> jobs;
-    for( auto it = inputFiles.begin(); it!=inputFiles.end(); it++ ) {
-        inputFile = it->c_str();
-
-        SiftJob* job = process_image( inputFile, PopSift );
+    for(const auto& currFile : inputFiles)
+    {
+        SiftJob* job = process_image( currFile, PopSift );
         jobs.push( job );
     }
 

--- a/src/application/main.cpp
+++ b/src/application/main.cpp
@@ -213,8 +213,8 @@ SiftJob* process_image( const string& inputFile, PopSift& PopSift )
         nvtxRangePushA( "load and convert image - pgmread" );
 
         image_data = readPGMfile( inputFile, w, h );
-        if( image_data == 0 ) {
             exit( -1 );
+        if( image_data == nullptr ) {
         }
 
         nvtxRangePop( ); // "load and convert image - pgmread"

--- a/src/application/main.cpp
+++ b/src/application/main.cpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <cmath>
 #include <iomanip>
-#include <stdlib.h>
+#include <cstdlib>
 #include <stdexcept>
 #include <list>
 #include <string>

--- a/src/application/main.cpp
+++ b/src/application/main.cpp
@@ -227,7 +227,7 @@ SiftJob* process_image( const string& inputFile, PopSift& PopSift )
         }
         else
         {
-            float* f_image_data = new float [w * h];
+            auto f_image_data = new float [w * h];
             for( int i=0; i<w*h; i++ )
             {
                 f_image_data[i] = float( image_data[i] ) / 256.0f;

--- a/src/application/main.cpp
+++ b/src/application/main.cpp
@@ -170,8 +170,6 @@ static void collectFilenames( list<string>& inputFiles, const boost::filesystem:
 
 SiftJob* process_image( const string& inputFile, PopSift& PopSift )
 {
-    int w;
-    int h;
     SiftJob* job;
     unsigned char* image_data;
 
@@ -195,8 +193,8 @@ SiftJob* process_image( const string& inputFile, PopSift& PopSift )
             cerr << "Failed converting image " << inputFile << " to unsigned greyscale image" << endl;
             exit( -1 );
         }
-        w = img.Width();
-        h = img.Height();
+        const auto w = img.Width();
+        const auto h = img.Height();
         cout << "Loading " << w << " x " << h << " image " << inputFile << endl;
 
         image_data = img.GetData();
@@ -211,7 +209,8 @@ SiftJob* process_image( const string& inputFile, PopSift& PopSift )
 #endif
     {
         nvtxRangePushA( "load and convert image - pgmread" );
-
+        int w{};
+        int h{};
         image_data = readPGMfile( inputFile, w, h );
         if( image_data == nullptr ) {
             exit( EXIT_FAILURE );

--- a/src/application/main.cpp
+++ b/src/application/main.cpp
@@ -268,8 +268,7 @@ int main(int argc, char **argv)
 
     popsift::Config config;
     list<string>   inputFiles;
-    string         inputFile = "";
-    const char*    appName   = argv[0];
+    string         inputFile{};
 
     try {
         parseargs( argc, argv, config, inputFile ); // Parse command line

--- a/src/application/main.cpp
+++ b/src/application/main.cpp
@@ -213,8 +213,8 @@ SiftJob* process_image( const string& inputFile, PopSift& PopSift )
         nvtxRangePushA( "load and convert image - pgmread" );
 
         image_data = readPGMfile( inputFile, w, h );
-            exit( -1 );
         if( image_data == nullptr ) {
+            exit( EXIT_FAILURE );
         }
 
         nvtxRangePop( ); // "load and convert image - pgmread"
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
     }
     catch (std::exception& e) {
         std::cout << e.what() << std::endl;
-        exit(1);
+        return EXIT_FAILURE;
     }
 
     if( boost::filesystem::exists( inputFile ) ) {
@@ -287,13 +287,13 @@ int main(int argc, char **argv)
             collectFilenames( inputFiles, inputFile );
             if( inputFiles.empty() ) {
                 cerr << "No files in directory, nothing to do" << endl;
-                exit( 0 );
+                return EXIT_SUCCESS;
             }
         } else if( boost::filesystem::is_regular_file( inputFile ) ) {
             inputFiles.push_back( inputFile );
         } else {
             cout << "Input file is neither regular file nor directory, nothing to do" << endl;
-            exit( -1 );
+            return EXIT_FAILURE;
         }
     }
 
@@ -324,5 +324,7 @@ int main(int argc, char **argv)
     }
 
     PopSift.uninit( );
+
+    return EXIT_SUCCESS;
 }
 

--- a/src/application/match.cpp
+++ b/src/application/match.cpp
@@ -202,7 +202,7 @@ SiftJob* process_image( const string& inputFile, PopSift& PopSift )
     {
         image_data = readPGMfile( inputFile, w, h );
         if( image_data == 0 ) {
-            exit( -1 );
+            exit( EXIT_FAILURE );
         }
 
         nvtxRangePop( );
@@ -231,20 +231,20 @@ int main(int argc, char **argv)
     }
     catch (std::exception& e) {
         std::cout << e.what() << std::endl;
-        exit(1);
+        return EXIT_SUCCESS;
     }
 
     if( boost::filesystem::exists( lFile ) ) {
         if( not boost::filesystem::is_regular_file( lFile ) ) {
             cout << "Input file " << lFile << " is not a regular file, nothing to do" << endl;
-            exit( -1 );
+            return EXIT_FAILURE;
         }
     }
 
     if( boost::filesystem::exists( rFile ) ) {
         if( not boost::filesystem::is_regular_file( rFile ) ) {
             cout << "Input file " << rFile << " is not a regular file, nothing to do" << endl;
-            exit( -1 );
+            return EXIT_FAILURE;
         }
     }
 
@@ -271,5 +271,7 @@ int main(int argc, char **argv)
     delete rFeatures;
 
     PopSift.uninit( );
+
+    return EXIT_SUCCESS;
 }
 

--- a/src/application/match.cpp
+++ b/src/application/match.cpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <cmath>
 #include <iomanip>
-#include <stdlib.h>
+#include <cstdlib>
 #include <stdexcept>
 #include <list>
 #include <string>

--- a/src/application/match.cpp
+++ b/src/application/match.cpp
@@ -38,11 +38,11 @@
 
 using namespace std;
 
-static bool print_dev_info  = false;
-static bool print_time_info = false;
-static bool write_as_uchar  = false;
-static bool dont_write      = false;
-static bool pgmread_loading = false;
+static bool print_dev_info  {false};
+static bool print_time_info {false};
+static bool write_as_uchar  {false};
+static bool dont_write      {false};
+static bool pgmread_loading {false};
 
 static void parseargs(int argc, char** argv, popsift::Config& config, string& lFile, string& rFile) {
     using namespace boost::program_options;
@@ -221,9 +221,8 @@ int main(int argc, char **argv)
     cudaDeviceReset();
 
     popsift::Config config;
-    string         lFile = "";
-    string         rFile = "";
-    const char*    appName   = argv[0];
+    string         lFile{};
+    string         rFile{};
 
     try {
         parseargs( argc, argv, config, lFile, rFile ); // Parse command line

--- a/src/application/match.cpp
+++ b/src/application/match.cpp
@@ -167,8 +167,6 @@ static void collectFilenames( list<string>& inputFiles, const boost::filesystem:
 
 SiftJob* process_image( const string& inputFile, PopSift& PopSift )
 {
-    int w;
-    int h;
     unsigned char* image_data;
     SiftJob* job;
 
@@ -185,8 +183,8 @@ SiftJob* process_image( const string& inputFile, PopSift& PopSift )
             cerr << "Failed converting image " << inputFile << " to unsigned greyscale image" << endl;
             exit( -1 );
         }
-        w = img.Width();
-        h = img.Height();
+        const auto w = img.Width();
+        const auto h = img.Height();
         cout << "Loading " << w << " x " << h << " image " << inputFile << endl;
         image_data = img.GetData();
 
@@ -200,8 +198,10 @@ SiftJob* process_image( const string& inputFile, PopSift& PopSift )
     else
 #endif
     {
+        int h{};
+        int w{};
         image_data = readPGMfile( inputFile, w, h );
-        if( image_data == 0 ) {
+        if( image_data == nullptr ) {
             exit( EXIT_FAILURE );
         }
 

--- a/src/application/pgmread.cpp
+++ b/src/application/pgmread.cpp
@@ -5,8 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-#include <stdlib.h>
-#include <iso646.h>
+#include <cstdlib>
 #include <iostream>
 #include <fstream>
 #include <boost/filesystem.hpp>

--- a/src/application/pgmread.cpp
+++ b/src/application/pgmread.cpp
@@ -69,12 +69,13 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
         return nullptr;
     }
 
-    char  line[1000];
     char* parse;
     int   maxval;
+    const int maxLineSize{1000};
+    char  line[maxLineSize];
 
     do {
-        pgmfile.getline( line, 1000 );
+        pgmfile.getline( line, maxLineSize );
 
         if( pgmfile.fail() ) {
             cerr << "File " << input_file << " is too short" << endl;
@@ -101,7 +102,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
     }
 
     do {
-        pgmfile.getline( line, 1000 );
+        pgmfile.getline( line, maxLineSize );
         if( pgmfile.fail() ) {
             cerr << "File " << input_file << " is too short" << endl;
             return nullptr;

--- a/src/application/pgmread.cpp
+++ b/src/application/pgmread.cpp
@@ -87,7 +87,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
             parse++;
         }
         if( *parse == '#' ) continue;
-        int ct = sscanf( parse, "%d %d", &w, &h );
+        const int ct = sscanf( parse, "%d %d", &w, &h );
         if( ct != 2 ) {
             cerr << "Error in " << __FILE__ << ":" << __LINE__ << endl
                  << "File " << input_file << " PGM type header (" << type << ") must be followed by comments and WxH info" << endl
@@ -113,7 +113,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
             parse++;
         }
         if( *parse == '#' ) continue;
-        int ct = sscanf( parse, "%d", &maxval );
+        const int ct = sscanf( parse, "%d", &maxval );
         if( ct != 1 ) {
             cerr << "File " << input_file << " PGM dimensions must be followed by comments and max value info" << endl;
             return nullptr;
@@ -161,15 +161,15 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
             }
             for( int i=0; i<w*h; i++ ) {
 #ifdef RGB2GRAY_IN_INT
-                unsigned int r = *src; src++;
-                unsigned int g = *src; src++;
-                unsigned int b = *src; src++;
-                unsigned int res = ( ( R_RATE*r+G_RATE*g+B_RATE*b ) >> RATE_SHIFT );
+                const unsigned int r = *src; src++;
+                const unsigned int g = *src; src++;
+                const unsigned int b = *src; src++;
+                const unsigned int res = ( ( R_RATE*r+G_RATE*g+B_RATE*b ) >> RATE_SHIFT );
                 input_data[i] = (unsigned char)res;
 #else // RGB2GRAY_IN_INT
-                float r = *src; src++;
-                float g = *src; src++;
-                float b = *src; src++;
+                const float r = *src; src++;
+                const float g = *src; src++;
+                const float b = *src; src++;
                 input_data[i] = (unsigned char)( R_RATE*r+G_RATE*g+B_RATE*b );
 #endif // RGB2GRAY_IN_INT
             }

--- a/src/application/pgmread.cpp
+++ b/src/application/pgmread.cpp
@@ -69,10 +69,10 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
         return nullptr;
     }
 
-    char* parse;
-    int   maxval;
     const int maxLineSize{1000};
     char  line[maxLineSize];
+    char* parse{nullptr};
+    int   maxval{};
 
     do {
         pgmfile.getline( line, maxLineSize );

--- a/src/application/pgmread.cpp
+++ b/src/application/pgmread.cpp
@@ -40,13 +40,13 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
 
     if( not boost::filesystem::exists( input_file ) ) {
         cerr << "File " << input_file << " does not exist" << endl;
-        return 0;
+        return nullptr;
     }
 
     ifstream pgmfile( filename.c_str(), ios::binary );
     if( not pgmfile.is_open() ) {
         cerr << "File " << input_file << " could not be opened for reading" << endl;
-        return 0;
+        return nullptr;
     }
 
     string pgmtype;
@@ -54,7 +54,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
         getline( pgmfile, pgmtype ); // this is the string version of getline()
         if( pgmfile.fail() ) {
             cerr << "File " << input_file << " is too short" << endl;
-            return 0;
+            return nullptr;
         }
         boost::algorithm::trim_left( pgmtype ); // nice because of trim
     } while( pgmtype.at(0) == '#' );
@@ -66,7 +66,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
     else if( pgmtype.substr(0,2) == "P6" ) type = 6;
     else {
         cerr << "File " << input_file << " can only contain P2, P3, P5 or P6 PGM images" << endl;
-        return 0;
+        return nullptr;
     }
 
     char  line[1000];
@@ -78,7 +78,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
 
         if( pgmfile.fail() ) {
             cerr << "File " << input_file << " is too short" << endl;
-            return 0;
+            return nullptr;
         }
         int num = pgmfile.gcount();
         parse = line;
@@ -91,20 +91,20 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
             cerr << "Error in " << __FILE__ << ":" << __LINE__ << endl
                  << "File " << input_file << " PGM type header (" << type << ") must be followed by comments and WxH info" << endl
                  << "but line contains " << parse << endl;
-            return 0;
+            return nullptr;
         }
     } while( *parse == '#' );
 
     if( w <= 0 || h <= 0 ) {
         cerr << "File " << input_file << " has meaningless image size" << endl;
-        return 0;
+        return nullptr;
     }
 
     do {
         pgmfile.getline( line, 1000 );
         if( pgmfile.fail() ) {
             cerr << "File " << input_file << " is too short" << endl;
-            return 0;
+            return nullptr;
         }
         int num = pgmfile.gcount();
         parse = line;
@@ -115,7 +115,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
         int ct = sscanf( parse, "%d", &maxval );
         if( ct != 1 ) {
             cerr << "File " << input_file << " PGM dimensions must be followed by comments and max value info" << endl;
-            return 0;
+            return nullptr;
         }
     } while( *parse == '#' );
 
@@ -135,7 +135,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
             if( pgmfile.fail() ) {
                 cerr << "File " << input_file << " file too short" << endl;
                 delete [] input_data;
-                return 0;
+                return nullptr;
             }
         }
         break;
@@ -155,7 +155,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
                     cerr << "File " << input_file << " file too short" << endl;
                     delete [] i2;
                     delete [] input_data;
-                    return 0;
+                    return nullptr;
                 }
             }
             for( int i=0; i<w*h; i++ ) {
@@ -185,7 +185,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
                 cerr << "File " << input_file << " file too short" << endl;
                 delete [] i2;
                 delete [] input_data;
-                return 0;
+                return nullptr;
             }
             for( int i=0; i<w*h; i++ ) {
                 input_data[i] = (unsigned char)(i2[i] * 255.0 / maxval );
@@ -202,7 +202,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
                 cerr << "File " << input_file << " file too short" << endl;
                 delete [] i2;
                 delete [] input_data;
-                return 0;
+                return nullptr;
             }
             for( int i=0; i<w*h; i++ ) {
 #ifdef RGB2GRAY_IN_INT

--- a/src/application/pgmread.cpp
+++ b/src/application/pgmread.cpp
@@ -120,7 +120,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
         }
     } while( *parse == '#' );
 
-    unsigned char* input_data = new unsigned char[ w * h ];
+    auto input_data = new unsigned char[ w * h ];
 
     switch( type )
     {
@@ -142,7 +142,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
         break;
     case 3 :
         {
-            unsigned char* i2 = new unsigned char[ w * h * 3 ];
+            auto i2 = new unsigned char[ w * h * 3 ];
             unsigned char* src = i2;
             for( int i=0; i<w*h*3; i++ ) {
                 int input;
@@ -180,7 +180,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
         if( maxval < 256 ) {
             pgmfile.read( (char*)input_data, w*h );
         } else {
-            unsigned short* i2 = new unsigned short[ w * h ];
+            auto i2 = new unsigned short[ w * h ];
             pgmfile.read( (char*)i2, w*h*2 );
             if( pgmfile.fail() ) {
                 cerr << "File " << input_file << " file too short" << endl;
@@ -196,7 +196,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
         break;
     case 6 :
         if( maxval < 256 ) {
-            unsigned char* i2 = new unsigned char[ w * h * 3 ];
+            auto i2 = new unsigned char[ w * h * 3 ];
             unsigned char* src = i2;
             pgmfile.read( (char*)i2, w*h*3 );
             if( pgmfile.fail() ) {
@@ -221,7 +221,7 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
             }
             delete [] i2;
         } else {
-            unsigned short* i2 = new unsigned short[ w * h * 2 * 3 ];
+            auto i2 = new unsigned short[ w * h * 2 * 3 ];
             unsigned short* src = i2;
             pgmfile.read( (char*)i2, w*h*2*3 );
             if( pgmfile.fail() ) {
@@ -247,6 +247,9 @@ unsigned char* readPGMfile( const string& filename, int& w, int& h )
             delete [] i2;
         }
         break;
+
+    default:
+        throw std::runtime_error("unsupported type " + std::to_string(type));
     }
 
     return input_data;


### PR DESCRIPTION
Boost 1.70 uses only the modern CMake way of `find_package()` and it imports both the targets and set the `Boost_LIBRARIES` variable with the found components targets (as opposed to the path to the libs).
This leads to a linking error for the examples as the variables are not set again with the proper targets (maybe a bug on boost side).
Here the variables are first voided before the `find_package()` and this seems to restore the correct behavior.

In the future, it would be better to completely switch to the modern CMake way (which requires to raise the CMake version at least to 3.5)