### PR TITLE
[cmake] add target file for in-build use

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,6 +123,10 @@ install(FILES "${project_config}" "${version_config}"
 install(EXPORT "${targets_export_name}"
         NAMESPACE "${namespace}"
         DESTINATION "${config_install_dir}")
+	
+# Generate ${PROJECT_NAME}Targets.cmake in the build directory too in case
+# you need to use the library without installing it
+export(TARGETS popsift FILE "${generated_dir}/${targets_export_name}.cmake")
 
 if(PopSift_BUILD_EXAMPLES)
   add_subdirectory(application)


### PR DESCRIPTION
The target file was not generated in the in-build.
It is needed if the lib is imported from the build directory (although not recommended)