### PR TITLE
Improved resource releasing

### DIFF
--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(PopsiftDemo)
+project(PopsiftDemo LANGUAGES CXX)
 
 if(TARGET popsift)
   # when compiled in the repository the target is already defined

--- a/src/popsift/popsift.cpp
+++ b/src/popsift/popsift.cpp
@@ -323,11 +323,13 @@ void PopSift::Pipe::uninit()
     {
         _thread_stage2->join();
         delete _thread_stage2;
+        _thread_stage2 = nullptr;
     }
     if(_thread_stage1 != nullptr)
     {
         _thread_stage1->join();
         delete _thread_stage1;
+        _thread_stage1 = nullptr;
     }
 
     while( !_unused.empty() )

--- a/src/popsift/popsift.cpp
+++ b/src/popsift/popsift.cpp
@@ -338,10 +338,7 @@ void PopSift::Pipe::uninit()
         delete img;
     }
 
-    if(_pyramid != nullptr)
-    {
-        delete _pyramid;
-        _pyramid    = nullptr;
-    }
+    delete _pyramid;
+    _pyramid    = nullptr;
 
 }

--- a/src/popsift/popsift.cpp
+++ b/src/popsift/popsift.cpp
@@ -14,7 +14,7 @@
 using namespace std;
 
 PopSift::PopSift( const popsift::Config& config, popsift::Config::ProcessingMode mode, ImageMode imode )
-    : _image_mode( imode ), _isInit(true)
+    : _image_mode( imode )
 {
     if( imode == ByteImages )
     {
@@ -38,7 +38,7 @@ PopSift::PopSift( const popsift::Config& config, popsift::Config::ProcessingMode
 }
 
 PopSift::PopSift( ImageMode imode )
-    : _image_mode( imode ), _isInit(true)
+    : _image_mode( imode )
 {
     if( imode == ByteImages )
     {

--- a/src/popsift/popsift.cpp
+++ b/src/popsift/popsift.cpp
@@ -26,7 +26,6 @@ PopSift::PopSift( const popsift::Config& config, popsift::Config::ProcessingMode
         _pipe._unused.push( new popsift::ImageFloat );
         _pipe._unused.push( new popsift::ImageFloat );
     }
-    _pipe._pyramid    = nullptr;
 
     configure( config, true );
 
@@ -50,7 +49,6 @@ PopSift::PopSift( ImageMode imode )
         _pipe._unused.push( new popsift::ImageFloat );
         _pipe._unused.push( new popsift::ImageFloat );
     }
-    _pipe._pyramid    = nullptr;
 
     _pipe._thread_stage1.reset( new boost::thread( &PopSift::uploadImages, this ));
     _pipe._thread_stage2.reset( new boost::thread( &PopSift::extractDownloadLoop, this ));

--- a/src/popsift/popsift.cpp
+++ b/src/popsift/popsift.cpp
@@ -30,11 +30,11 @@ PopSift::PopSift( const popsift::Config& config, popsift::Config::ProcessingMode
 
     configure( config, true );
 
-    _pipe._thread_stage1 = new boost::thread( &PopSift::uploadImages, this );
+    _pipe._thread_stage1.reset( new boost::thread( &PopSift::uploadImages, this ));
     if( mode == popsift::Config::ExtractingMode )
-        _pipe._thread_stage2 = new boost::thread( &PopSift::extractDownloadLoop, this );
+        _pipe._thread_stage2.reset( new boost::thread( &PopSift::extractDownloadLoop, this ));
     else
-        _pipe._thread_stage2 = new boost::thread( &PopSift::matchPrepareLoop, this );
+        _pipe._thread_stage2.reset( new boost::thread( &PopSift::matchPrepareLoop, this ));
 }
 
 PopSift::PopSift( ImageMode imode )
@@ -52,8 +52,8 @@ PopSift::PopSift( ImageMode imode )
     }
     _pipe._pyramid    = nullptr;
 
-    _pipe._thread_stage1 = new boost::thread( &PopSift::uploadImages, this );
-    _pipe._thread_stage2 = new boost::thread( &PopSift::extractDownloadLoop, this );
+    _pipe._thread_stage1.reset( new boost::thread( &PopSift::uploadImages, this ));
+    _pipe._thread_stage2.reset( new boost::thread( &PopSift::extractDownloadLoop, this ));
 }
 
 PopSift::~PopSift()
@@ -322,14 +322,12 @@ void PopSift::Pipe::uninit()
     if(_thread_stage2 != nullptr)
     {
         _thread_stage2->join();
-        delete _thread_stage2;
-        _thread_stage2 = nullptr;
+        _thread_stage2.reset(nullptr);
     }
     if(_thread_stage1 != nullptr)
     {
         _thread_stage1->join();
-        delete _thread_stage1;
-        _thread_stage1 = nullptr;
+        _thread_stage1.reset(nullptr);
     }
 
     while( !_unused.empty() )

--- a/src/popsift/popsift.cpp
+++ b/src/popsift/popsift.cpp
@@ -26,7 +26,7 @@ PopSift::PopSift( const popsift::Config& config, popsift::Config::ProcessingMode
         _pipe._unused.push( new popsift::ImageFloat );
         _pipe._unused.push( new popsift::ImageFloat );
     }
-    _pipe._pyramid    = 0;
+    _pipe._pyramid    = nullptr;
 
     configure( config, true );
 
@@ -50,7 +50,7 @@ PopSift::PopSift( ImageMode imode )
         _pipe._unused.push( new popsift::ImageFloat );
         _pipe._unused.push( new popsift::ImageFloat );
     }
-    _pipe._pyramid    = 0;
+    _pipe._pyramid    = nullptr;
 
     _pipe._thread_stage1 = new boost::thread( &PopSift::uploadImages, this );
     _pipe._thread_stage2 = new boost::thread( &PopSift::extractDownloadLoop, this );
@@ -62,7 +62,7 @@ PopSift::~PopSift()
 
 bool PopSift::configure( const popsift::Config& config, bool force )
 {
-    if( _pipe._pyramid != 0 ) {
+    if( _pipe._pyramid != nullptr ) {
         return false;
     }
 
@@ -97,7 +97,7 @@ bool PopSift::private_init( int w, int h )
     float upscaleFactor = _config.getUpscaleFactor();
     float scaleFactor = 1.0f / powf( 2.0f, -upscaleFactor );
 
-    if( p._pyramid != 0 ) {
+    if( p._pyramid != nullptr ) {
         p._pyramid->resetDimensions( _config,
                                      ceilf( w * scaleFactor ),
                                      ceilf( h * scaleFactor ) );
@@ -171,12 +171,12 @@ SiftJob* PopSift::enqueue( int          w,
 void PopSift::uploadImages( )
 {
     SiftJob* job;
-    while( ( job = _pipe._queue_stage1.pull() ) != 0 ) {
+    while( ( job = _pipe._queue_stage1.pull() ) != nullptr ) {
         popsift::ImageBase* img = _pipe._unused.pull();
         job->setImg( img );
         _pipe._queue_stage2.push( job );
     }
-    _pipe._queue_stage2.push( 0 );
+    _pipe._queue_stage2.push( nullptr );
 }
 
 void PopSift::extractDownloadLoop( )
@@ -184,7 +184,7 @@ void PopSift::extractDownloadLoop( )
     Pipe& p = _pipe;
 
     SiftJob* job;
-    while( ( job = p._queue_stage2.pull() ) != 0 ) {
+    while( ( job = p._queue_stage2.pull() ) != nullptr ) {
         popsift::ImageBase* img = job->getImg();
 
         private_init( img->getWidth(), img->getHeight() );
@@ -217,7 +217,7 @@ void PopSift::matchPrepareLoop( )
     Pipe& p = _pipe;
 
     SiftJob* job;
-    while( ( job = p._queue_stage2.pull() ) != 0 ) {
+    while( ( job = p._queue_stage2.pull() ) != nullptr ) {
         popsift::ImageBase* img = job->getImg();
 
         private_init( img->getWidth(), img->getHeight() );
@@ -238,12 +238,12 @@ void PopSift::matchPrepareLoop( )
 SiftJob::SiftJob( int w, int h, const unsigned char* imageData )
     : _w(w)
     , _h(h)
-    , _img(0)
+    , _img(nullptr)
 {
     _f = _p.get_future();
 
     _imageData = (unsigned char*)malloc( w*h );
-    if( _imageData != 0 ) {
+    if( _imageData != nullptr ) {
         memcpy( _imageData, imageData, w*h );
     } else {
         cerr << __FILE__ << ":" << __LINE__ << " Memory limitation" << endl
@@ -255,12 +255,12 @@ SiftJob::SiftJob( int w, int h, const unsigned char* imageData )
 SiftJob::SiftJob( int w, int h, const float* imageData )
     : _w(w)
     , _h(h)
-    , _img(0)
+    , _img(nullptr)
 {
     _f = _p.get_future();
 
     _imageData = (unsigned char*)malloc( w*h*sizeof(float) );
-    if( _imageData != 0 ) {
+    if( _imageData != nullptr ) {
         memcpy( _imageData, imageData, w*h*sizeof(float) );
     } else {
         cerr << __FILE__ << ":" << __LINE__ << " Memory limitation" << endl

--- a/src/popsift/popsift.h
+++ b/src/popsift/popsift.h
@@ -74,13 +74,13 @@ class PopSift
 {
     struct Pipe
     {
-        boost::thread*                         _thread_stage1;
-        boost::thread*                         _thread_stage2;
+        boost::thread*                         _thread_stage1{nullptr};
+        boost::thread*                         _thread_stage2{nullptr};
         boost::sync_queue<SiftJob*>            _queue_stage1;
         boost::sync_queue<SiftJob*>            _queue_stage2;
         boost::sync_queue<popsift::ImageBase*> _unused;
 
-        popsift::Pyramid*                      _pyramid;
+        popsift::Pyramid*                      _pyramid{nullptr};
 
         /**
          * @brief Release the allocated resources, if any.

--- a/src/popsift/popsift.h
+++ b/src/popsift/popsift.h
@@ -74,8 +74,8 @@ class PopSift
 {
     struct Pipe
     {
-        std::unique_ptr<boost::thread>         _thread_stage1{nullptr};
-        std::unique_ptr<boost::thread>         _thread_stage2{nullptr};
+        std::unique_ptr<boost::thread>         _thread_stage1;
+        std::unique_ptr<boost::thread>         _thread_stage2;
         boost::sync_queue<SiftJob*>            _queue_stage1;
         boost::sync_queue<SiftJob*>            _queue_stage2;
         boost::sync_queue<popsift::ImageBase*> _unused;

--- a/src/popsift/popsift.h
+++ b/src/popsift/popsift.h
@@ -173,8 +173,8 @@ private:
      */
     popsift::Config _shadow_config;
 
-    int             _last_init_w; /* to support depreacted interface */
-    int             _last_init_h; /* to support depreacted interface */
+    int             _last_init_w{}; /* to support deprecated interface */
+    int             _last_init_h{}; /* to support deprecated interface */
     ImageMode       _image_mode;
 
     /// whether the object is initialized

--- a/src/popsift/popsift.h
+++ b/src/popsift/popsift.h
@@ -96,6 +96,10 @@ public:
     };
 
 public:
+
+    PopSift() = delete;
+    PopSift(const PopSift&) = delete;
+
     /* We support more than 1 streams, but we support only one sigma and one
      * level parameters.
      */
@@ -174,6 +178,6 @@ private:
     ImageMode       _image_mode;
 
     /// whether the object is initialized
-    bool            _isInit{false};
+    bool            _isInit{true};
 };
 

--- a/src/popsift/popsift.h
+++ b/src/popsift/popsift.h
@@ -79,7 +79,6 @@ class PopSift
         boost::sync_queue<SiftJob*>            _queue_stage1;
         boost::sync_queue<SiftJob*>            _queue_stage2;
         boost::sync_queue<popsift::ImageBase*> _unused;
-        popsift::ImageBase*                    _current;
 
         popsift::Pyramid*                      _pyramid;
 

--- a/src/popsift/popsift.h
+++ b/src/popsift/popsift.h
@@ -74,8 +74,8 @@ class PopSift
 {
     struct Pipe
     {
-        boost::thread*                         _thread_stage1{nullptr};
-        boost::thread*                         _thread_stage2{nullptr};
+        std::unique_ptr<boost::thread>         _thread_stage1{nullptr};
+        std::unique_ptr<boost::thread>         _thread_stage2{nullptr};
         boost::sync_queue<SiftJob*>            _queue_stage1;
         boost::sync_queue<SiftJob*>            _queue_stage2;
         boost::sync_queue<popsift::ImageBase*> _unused;

--- a/src/popsift/popsift.h
+++ b/src/popsift/popsift.h
@@ -82,6 +82,11 @@ class PopSift
         popsift::ImageBase*                    _current;
 
         popsift::Pyramid*                      _pyramid;
+
+        /**
+         * @brief Release the allocated resources, if any.
+         */
+        void uninit();
     };
 
 public:
@@ -95,8 +100,8 @@ public:
     /* We support more than 1 streams, but we support only one sigma and one
      * level parameters.
      */
-    PopSift( ImageMode imode = ByteImages );
-    PopSift( const popsift::Config&          config,
+    explicit PopSift( ImageMode imode = ByteImages );
+    explicit PopSift( const popsift::Config&          config,
              popsift::Config::ProcessingMode mode  = popsift::Config::ExtractingMode,
              ImageMode                       imode = ByteImages );
     ~PopSift();
@@ -118,10 +123,14 @@ public:
                        int          h,
                        const float* imageData );
 
-    /** deprecated */
+    /**
+     * @deprecated
+     * */
     inline void uninit( int /*pipe*/ ) { uninit(); }
 
-    /** deprecated */
+    /**
+     * @deprecated
+     **/
     inline bool init( int /*pipe*/, int w, int h ) {
         _last_init_w = w;
         _last_init_h = h;
@@ -164,5 +173,8 @@ private:
     int             _last_init_w; /* to support depreacted interface */
     int             _last_init_h; /* to support depreacted interface */
     ImageMode       _image_mode;
+
+    /// whether the object is initialized
+    bool            _isInit{false};
 };
 


### PR DESCRIPTION
As per #70, it introduces a state attribute `_isInit` in the class `PopSift` so that the `uninit()` method to release the resources can be called explicitly or in the destructor of the class at the end of the object scope.

the `uninit()` method is also replicated inside the class `Pipe` to release the relevant resources.

Incidentally, using `nullptr` instead of 0

closes #70