### PR TITLE
Resolve race conditions identified by racecheck.

### DIFF
--- a/src/popsift/common/excl_blk_prefix_sum.h
+++ b/src/popsift/common/excl_blk_prefix_sum.h
@@ -132,16 +132,15 @@ private:
                 _mapping_writer.set( ebs, self, cell );
             }
 
+            // Wait to update loop_total until everyone is done.
+            __syncthreads();
             if( threadIdx.y == 0 && threadIdx.x == 31 ) {
                 loop_total += ibs;
             }
-            __syncthreads();
         }
 
-        // if( threadIdx.y == 0 && threadIdx.x == 31 )
-        if( threadIdx.y == 0 )
+        if( threadIdx.y == 0 && threadIdx.x == 31 )
         {
-            loop_total = popsift::shuffle( loop_total, 31 );
             _total_writer.set( loop_total );
         }
     }

--- a/src/popsift/common/excl_blk_prefix_sum.h
+++ b/src/popsift/common/excl_blk_prefix_sum.h
@@ -137,12 +137,10 @@ private:
             if( threadIdx.y == 0 && threadIdx.x == 31 ) {
                 loop_total += ibs;
             }
+            __syncthreads();
         }
 
-        if( threadIdx.y == 0 && threadIdx.x == 31 )
-        {
-            _total_writer.set( loop_total );
-        }
+        _total_writer.set( loop_total );
     }
 };
 

--- a/src/popsift/common/excl_blk_prefix_sum.h
+++ b/src/popsift/common/excl_blk_prefix_sum.h
@@ -73,6 +73,7 @@ private:
         if( threadIdx.x == 0 && threadIdx.y == 0 ) {
             loop_total = 0;
         }
+        __syncthreads();
 
         const int start = threadIdx.y * blockDim.x + threadIdx.x;
         const int wrap  = blockDim.x * blockDim.y;
@@ -131,9 +132,8 @@ private:
                  */
                 _mapping_writer.set( ebs, self, cell );
             }
-
-            // Wait to update loop_total until everyone is done.
             __syncthreads();
+
             if( threadIdx.y == 0 && threadIdx.x == 31 ) {
                 loop_total += ibs;
             }

--- a/src/popsift/common/excl_blk_prefix_sum.h
+++ b/src/popsift/common/excl_blk_prefix_sum.h
@@ -73,7 +73,6 @@ private:
         if( threadIdx.x == 0 && threadIdx.y == 0 ) {
             loop_total = 0;
         }
-        __syncthreads();
 
         const int start = threadIdx.y * blockDim.x + threadIdx.x;
         const int wrap  = blockDim.x * blockDim.y;

--- a/src/popsift/s_orientation.cu
+++ b/src/popsift/s_orientation.cu
@@ -75,6 +75,7 @@ void ori_par( const int           octave,
     __shared__ float sm_hist[ORI_NBINS];
 
     for( int i = threadIdx.x; i < ORI_NBINS; i += blockDim.x )  hist[i] = 0.0f;
+    __syncthreads();
 
     /* keypoint fractional geometry */
     const float x     = iext->xpos;
@@ -206,6 +207,7 @@ void ori_par( const int           octave,
 
     int2 best_index = make_int2( threadIdx.x, threadIdx.x + 32 );
 
+    __syncthreads();
     BitonicSort::Warp32<float> sorter( yval );
     sorter.sort64( best_index );
     __syncthreads();

--- a/src/popsift/s_orientation.cu
+++ b/src/popsift/s_orientation.cu
@@ -204,10 +204,10 @@ void ori_par( const int           octave,
         refined_angle[bin] = predicate ? prev + newbin : -1;
         yval[bin]          = predicate ?  -(num*num) / (4.0f * denB) + sm_hist[prev] : -INFINITY;
     }
+    __syncthreads();
 
     int2 best_index = make_int2( threadIdx.x, threadIdx.x + 32 );
 
-    __syncthreads();
     BitonicSort::Warp32<float> sorter( yval );
     sorter.sort64( best_index );
     __syncthreads();


### PR DESCRIPTION
This PR resolves a few read/write race conditions identified by the `racecheck` tool. I stumbled onto them while naively trying to investigate issue #80.
```bash
cuda-memcheck --tool racecheck ./popsift-demo -i /path/to/oxford/boat/img1.pgm
```

The `__syncthreads()` on L78 resolves the race found below; memory needed to be initialized prior to the `AtomicAdd()`.
```text
========= WARN: Race reported between Write access at 0x00000ed0 in popsift::ori_par(int, int, __int64, int, int)
=========     and Read access at 0x00000150 in __fAtomicAdd [68 hazards]
```


The `__syncthreads()` on L210 resolves this race found below;  threads had to finish writing to `yval` prior to passing the collection to the `BitonicSort`:
```text
========= WARN: Race reported between Write access at 0x00006210 in popsift::ori_par(int, int, __int64, int, int)
=========     and Read access at 0x000003d0 in popsift::BitonicSort::Warp32<float>::shiftit(int, int, int, bool) [256 hazards]
```

I've updated the PR with two additional commits that resolve a race condition in the block based prefix sum.
