### PR TITLE
[doc] Update Popart link

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If you use PopSift for your publication, please cite us as:
 
 ## Acknowledgements
 
-PopSift was developed within the project [POPART](https://cordis.europa.eu/project/id/644874), which has been funded by the European Commission in the Horizon 2020 framework.
+PopSift was developed within the project [POPART](https://alicevision.org/popart), which has been funded by the European Commission in the Horizon 2020 framework.
 
 ___
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If you use PopSift for your publication, please cite us as:
 
 ## Acknowledgements
 
-PopSift was developed within the project [POPART](https://alicevision.org/popart), which has been funded by the European Commission in the Horizon 2020 framework.
+PopSift was developed within the project [POPART](https://alicevision.org/popart), which has been funded by the [European Commission in the Horizon 2020](https://cordis.europa.eu/project/id/644874) framework.
 
 ___
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If you use PopSift for your publication, please cite us as:
 
 ## Acknowledgements
 
-PopSift was developed within the project [POPART](http://www.popartproject.eu), which has been funded by the European Commission in the Horizon 2020 framework.
+PopSift was developed within the project [POPART](https://cordis.europa.eu/project/id/644874), which has been funded by the European Commission in the Horizon 2020 framework.
 
 ___
 


### PR DESCRIPTION
The old POPART project page points to strange stuff, as noted in Issue #83 .
Fix the POPART URL in README.md: It is now pointing to the Cordis web page for POPART.
