### PR TITLE
[docker] update cmake and split docker in 2 parts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,3 +20,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for cuda 9 and 10
 - Support for RTX architecture
 - Optional grid filtering
+- Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-ARG CUDA_TAG=9.2-devel
-FROM nvidia/cuda:$CUDA_TAG
+ARG CUDA_TAG=10.2
+ARG OS_TAG=18.04
+FROM alicevision/popsift:deps-cuda${CUDA_TAG}-ubuntu${OS_TAG}
 LABEL maintainer="AliceVision Team alicevision@googlegroups.com"
 
 # use CUDA_TAG to select the image version to use
@@ -16,32 +17,9 @@ LABEL maintainer="AliceVision Team alicevision@googlegroups.com"
 # Cuda version (ENV): $CUDA_VERSION
 
 # System update
-RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommends\
-        build-essential \
-        wget \
-        unzip \
-        libtool \
-        automake \
-        libssl-dev \
-        libpng12-dev \
-        libjpeg-turbo8-dev \
-        libdevil-dev \
-        libboost-filesystem-dev \
-        libboost-system-dev \
-        libboost-program-options-dev \
-        libboost-thread-dev \
- && rm -rf /var/lib/apt/lists/*
- 
- # Manually install cmake
-WORKDIR /tmp/cmake
-RUN wget https://cmake.org/files/v3.17/cmake-3.17.1.tar.gz && \
-    tar zxvf cmake-3.17.1.tar.gz
-WORKDIR /tmp/cmake/cmake-3.17.1
-RUN ./bootstrap --prefix=/usr/local  -- -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_USE_OPENSSL:BOOL=ON && \
-    make -j2 install
-WORKDIR /tmp
-RUN rm -rf cmake
-
 COPY . /opt/popsift
 WORKDIR /opt/popsift/build
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release && make install -j 2
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release && \
+    make install -j $(nproc) && \
+    cd /opt && \
+    rm -rf popsift

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,11 @@ LABEL maintainer="AliceVision Team alicevision@googlegroups.com"
 # System update
 RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommends\
         build-essential \
-        cmake \
-        git \
         wget \
         unzip \
-        yasm \
-        pkg-config \
         libtool \
-        nasm \
         automake \
+        libssl-dev \
         libpng12-dev \
         libjpeg-turbo8-dev \
         libdevil-dev \
@@ -35,7 +31,17 @@ RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommend
         libboost-program-options-dev \
         libboost-thread-dev \
  && rm -rf /var/lib/apt/lists/*
+ 
+ # Manually install cmake
+WORKDIR /tmp/cmake
+RUN wget https://cmake.org/files/v3.17/cmake-3.17.1.tar.gz && \
+    tar zxvf cmake-3.17.1.tar.gz && \
+    cd cmake-3.17.1 && \
+    ./bootstrap --prefix=/usr/local  -- -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_USE_OPENSSL:BOOL=ON && \
+    make -j2 install && \
+    cd /tmp && \
+    rm -rf cmake
 
 COPY . /opt/popsift
 WORKDIR /opt/popsift/build
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release && make install -j
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release && make install -j 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG CUDA_TAG=10.2
 ARG OS_TAG=18.04
-FROM alicevision/popsift:deps-cuda${CUDA_TAG}-ubuntu${OS_TAG}
+FROM alicevision/popsift-deps:cuda${CUDA_TAG}-ubuntu${OS_TAG}
 LABEL maintainer="AliceVision Team alicevision@googlegroups.com"
 
 # use CUDA_TAG to select the image version to use

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,12 @@ RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommend
  # Manually install cmake
 WORKDIR /tmp/cmake
 RUN wget https://cmake.org/files/v3.17/cmake-3.17.1.tar.gz && \
-    tar zxvf cmake-3.17.1.tar.gz && \
-    cd cmake-3.17.1 && \
-    ./bootstrap --prefix=/usr/local  -- -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_USE_OPENSSL:BOOL=ON && \
-    make -j2 install && \
-    cd /tmp && \
-    rm -rf cmake
+    tar zxvf cmake-3.17.1.tar.gz
+WORKDIR /tmp/cmake/cmake-3.17.1
+RUN ./bootstrap --prefix=/usr/local  -- -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_USE_OPENSSL:BOOL=ON && \
+    make -j2 install
+WORKDIR /tmp
+RUN rm -rf cmake
 
 COPY . /opt/popsift
 WORKDIR /opt/popsift/build

--- a/Dockerfile_deps
+++ b/Dockerfile_deps
@@ -7,7 +7,7 @@ LABEL maintainer="AliceVision Team alicevision@googlegroups.com"
 # see https://hub.docker.com/r/nvidia/cuda/
 #
 # For example, to create a ubuntu 16.04 with cuda 8.0 for development, use
-# docker build --build-arg CUDA_TAG=8.0 --tag alicevision/popsift:deps-cuda${CUDA_TAG}-ubuntu${OS_TAG} .
+# docker build --build-arg CUDA_TAG=8.0 --tag alicevision/popsift-deps:cuda${CUDA_TAG}-ubuntu${OS_TAG} .
 #
 # then execute with nvidia docker (https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0))
 # docker run -it --runtime=nvidia popsift_deps

--- a/Dockerfile_deps
+++ b/Dockerfile_deps
@@ -1,0 +1,46 @@
+ARG CUDA_TAG=10.2
+ARG OS_TAG=18.04
+FROM nvidia/cuda:${CUDA_TAG}-devel-ubuntu${OS_TAG}
+LABEL maintainer="AliceVision Team alicevision@googlegroups.com"
+
+# use CUDA_TAG to select the image version to use
+# see https://hub.docker.com/r/nvidia/cuda/
+#
+# For example, to create a ubuntu 16.04 with cuda 8.0 for development, use
+# docker build --build-arg CUDA_TAG=8.0 --tag alicevision/popsift:deps-cuda${CUDA_TAG}-ubuntu${OS_TAG} .
+#
+# then execute with nvidia docker (https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0))
+# docker run -it --runtime=nvidia popsift_deps
+
+
+# OS/Version (FILE): cat /etc/issue.net
+# Cuda version (ENV): $CUDA_VERSION
+
+# System update
+RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommends\
+        build-essential \
+        wget \
+        unzip \
+        libtool \
+        automake \
+        libssl-dev \
+        libpng12-dev \
+        libjpeg-turbo8-dev \
+        libdevil-dev \
+        libboost-filesystem-dev \
+        libboost-system-dev \
+        libboost-program-options-dev \
+        libboost-thread-dev \
+ && rm -rf /var/lib/apt/lists/*
+ 
+ # Manually install cmake
+WORKDIR /tmp/cmake
+ENV CMAKE_VERSION=3.17
+ENV CMAKE_VERSION_FULL=${CMAKE_VERSION}.2
+RUN wget https://cmake.org/files/v3.17/cmake-${CMAKE_VERSION_FULL}.tar.gz && \
+    tar zxvf cmake-${CMAKE_VERSION_FULL}.tar.gz && \
+    cd cmake-${CMAKE_VERSION_FULL} && \
+    ./bootstrap --prefix=/usr/local  -- -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_USE_OPENSSL:BOOL=ON && \
+    make -j8 install && \
+    cd /tmp && \
+    rm -rf cmake

--- a/Dockerfile_deps
+++ b/Dockerfile_deps
@@ -24,7 +24,6 @@ RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommend
         libtool \
         automake \
         libssl-dev \
-        libpng12-dev \
         libjpeg-turbo8-dev \
         libdevil-dev \
         libboost-filesystem-dev \
@@ -41,6 +40,6 @@ RUN wget https://cmake.org/files/v3.17/cmake-${CMAKE_VERSION_FULL}.tar.gz && \
     tar zxvf cmake-${CMAKE_VERSION_FULL}.tar.gz && \
     cd cmake-${CMAKE_VERSION_FULL} && \
     ./bootstrap --prefix=/usr/local  -- -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_USE_OPENSSL:BOOL=ON && \
-    make -j8 install && \
+    make -j$(nproc) install && \
     cd /tmp && \
     rm -rf cmake


### PR DESCRIPTION
Update docker file
* build the last version of cmake
* remove unnecessary dependencies
* split the docker file in 2, one `Dockerfile_deps` to build a base image with the dependencies (to be used eg for CI) and the actual image