### PR TITLE
test whether image fits into CUDA textures

### DIFF
--- a/src/popsift/common/debug_macros.h
+++ b/src/popsift/common/debug_macros.h
@@ -138,6 +138,14 @@ public:
         std::cerr << __FILE__ << ":" << __LINE__ << std::endl << "    " << s << std::endl; \
     }
 
+#define POP_WARN(s) { \
+        std::cerr << __FILE__ << ":" << __LINE__ << std::endl; \
+        std::cerr << "    WARNING: " << s << std::endl; \
+    }
+#define POP_CUDA_WARN(err,s) { \
+        std::cerr << __FILE__ << ":" << __LINE__ << std::endl; \
+        std::cerr << "    WARNING: " << s << cudaGetErrorString(err) << std::endl; \
+    }
 #define POP_CUDA_FATAL(err,s) { \
         std::cerr << __FILE__ << ":" << __LINE__ << std::endl; \
         std::cerr << "    " << s << cudaGetErrorString(err) << std::endl; \

--- a/src/popsift/common/device_prop.cu
+++ b/src/popsift/common/device_prop.cu
@@ -17,18 +17,24 @@ using namespace std;
 
 device_prop_t::device_prop_t( )
 {
+    int         currentDevice;
     cudaError_t err;
+
+    err = cudaGetDevice( &currentDevice );
+    POP_CUDA_FATAL_TEST( err, "Cannot get the current CUDA device" );
 
     err = cudaGetDeviceCount( &_num_devices );
     POP_CUDA_FATAL_TEST( err, "Cannot count devices" );
 
+    _properties.resize(_num_devices);
+
     for( int n=0; n<_num_devices; n++ ) {
-        cudaDeviceProp* p;
-        _properties.push_back( p = new cudaDeviceProp );
-        err = cudaGetDeviceProperties( p, n );
+        _properties[n] = new cudaDeviceProp;
+        err = cudaGetDeviceProperties( _properties[n], n );
         POP_CUDA_FATAL_TEST( err, "Cannot get properties for a device" );
     }
-    err = cudaSetDevice( 0 );
+
+    err = cudaSetDevice( currentDevice );
     POP_CUDA_FATAL_TEST( err, "Cannot set device 0" );
 }
 
@@ -84,6 +90,222 @@ device_prop_t::~device_prop_t( )
         cudaDeviceProp* ptr = *p;
         delete ptr;
     }
+}
+
+bool device_prop_t::checkLimit_2DtexLinear( int& width, int& height, bool printWarn ) const
+{
+    bool        returnSuccess = true;
+    int         currentDevice;
+    cudaError_t err;
+
+    err = cudaGetDevice( &currentDevice );
+    if( err != cudaSuccess )
+    {
+        POP_CUDA_WARN( err, "Cannot get current CUDA device" );
+        return true;
+    }
+
+    if( currentDevice >= _properties.size() )
+    {
+        POP_WARN( "CUDA device was not registered at program start" );
+        return true;
+    }
+
+    const cudaDeviceProp* ptr = _properties[currentDevice];
+    if( width > ptr->maxTexture2DLayered[0] )
+    {
+        if( printWarn )
+        {
+            std::cerr << __FILE__ << ":" << __LINE__
+                      << ": CUDA device " << currentDevice << std::endl
+                      << "    does not support 2D linear textures " << width
+                      << " pixels wide." << endl;
+        }
+        width = ptr->maxTexture2DLayered[0];
+        returnSuccess = false;
+    }
+    if( height > ptr->maxTexture2DLayered[1] )
+    {
+        if( returnSuccess && printWarn )
+        {
+            std::cerr << __FILE__ << ":" << __LINE__
+                      << ": CUDA device " << currentDevice << std::endl
+                      << "    does not support 2D linear textures " << height
+                      << " pixels high." << endl;
+        }
+        height = ptr->maxTexture2DLayered[1];
+        returnSuccess = false;
+    }
+
+    return returnSuccess;
+}
+
+bool device_prop_t::checkLimit_2DtexArray( int& width, int& height, bool printWarn ) const
+{
+    bool        returnSuccess = true;
+    int         currentDevice;
+    cudaError_t err;
+
+    err = cudaGetDevice( &currentDevice );
+    if( err != cudaSuccess )
+    {
+        POP_CUDA_WARN( err, "Cannot get current CUDA device" );
+        return true;
+    }
+
+    if( currentDevice >= _properties.size() )
+    {
+        POP_WARN( "CUDA device was not registered at program start" );
+        return true;
+    }
+
+    const cudaDeviceProp* ptr = _properties[currentDevice];
+    if( width > ptr->maxTexture2D[0] )
+    {
+        if( printWarn )
+        {
+            std::cerr << __FILE__ << ":" << __LINE__
+                      << ": CUDA device " << currentDevice << std::endl
+                      << "    does not support 2D array textures " << width
+                      << " pixels wide." << endl;
+        }
+        width = ptr->maxTexture2D[0];
+        returnSuccess = false;
+    }
+    if( height > ptr->maxTexture2D[1] )
+    {
+        if( returnSuccess && printWarn )
+        {
+            std::cerr << __FILE__ << ":" << __LINE__
+                      << ": CUDA device " << currentDevice << std::endl
+                      << "    does not support 2D array textures " << height
+                      << " pixels high." << endl;
+        }
+        height = ptr->maxTexture2D[1];
+        returnSuccess = false;
+    }
+
+    return returnSuccess;
+}
+
+bool device_prop_t::checkLimit_2DtexLayered( int& width, int& height, int& layers, bool printWarn ) const
+{
+    bool        returnSuccess = true;
+    int         currentDevice;
+    cudaError_t err;
+
+    err = cudaGetDevice( &currentDevice );
+    if( err != cudaSuccess )
+    {
+        POP_CUDA_WARN( err, "Cannot get current CUDA device" );
+        return true;
+    }
+
+    if( currentDevice >= _properties.size() )
+    {
+        POP_WARN( "CUDA device was not registered at program start" );
+        return true;
+    }
+
+    const cudaDeviceProp* ptr = _properties[currentDevice];
+    if( width > ptr->maxTexture2DLayered[0] )
+    {
+        if( printWarn )
+        {
+            std::cerr << __FILE__ << ":" << __LINE__
+                      << ": CUDA device " << currentDevice << std::endl
+                      << "    does not support 2D array textures " << width
+                      << " pixels wide." << endl;
+        }
+        width = ptr->maxTexture2DLayered[0];
+        returnSuccess = false;
+    }
+    if( height > ptr->maxTexture2DLayered[1] )
+    {
+        if( returnSuccess && printWarn )
+        {
+            std::cerr << __FILE__ << ":" << __LINE__
+                      << ": CUDA device " << currentDevice << std::endl
+                      << "    does not support 2D array textures " << height
+                      << " pixels high." << endl;
+        }
+        height = ptr->maxTexture2DLayered[1];
+        returnSuccess = false;
+    }
+    if( layers > ptr->maxTexture2DLayered[2] )
+    {
+        if( returnSuccess && printWarn )
+        {
+            std::cerr << __FILE__ << ":" << __LINE__
+                      << ": CUDA device " << currentDevice << std::endl
+                      << "    does not support 2D array textures " << layers
+                      << " pixels deep." << endl;
+        }
+        layers = ptr->maxTexture2DLayered[2];
+        returnSuccess = false;
+    }
+
+    return returnSuccess;
+}
+
+bool device_prop_t::checkLimit_2DsurfLayered( int& width, int& height, int& layers, bool printWarn ) const
+{
+    bool        returnSuccess = true;
+    int         currentDevice;
+    cudaError_t err;
+
+    err = cudaGetDevice( &currentDevice );
+    if( err != cudaSuccess )
+    {
+        POP_CUDA_WARN( err, "Cannot get current CUDA device" );
+        return true;
+    }
+
+    if( currentDevice >= _properties.size() )
+    {
+        POP_WARN( "CUDA device was not registered at program start" );
+        return true;
+    }
+
+    const cudaDeviceProp* ptr = _properties[currentDevice];
+    if( width > ptr->maxSurface2DLayered[0] )
+    {
+        if( printWarn )
+        {
+            std::cerr << __FILE__ << ":" << __LINE__
+                      << ": CUDA device " << currentDevice << std::endl
+                      << "    does not support layered 2D surfaces " << width
+                      << " bytes wide." << endl;
+        }
+        width = ptr->maxSurface2DLayered[0];
+        returnSuccess = false;
+    }
+    if( height > ptr->maxSurface2DLayered[1] )
+    {
+        if( returnSuccess && printWarn )
+        {
+            std::cerr << __FILE__ << ":" << __LINE__
+                      << ": CUDA device " << currentDevice << std::endl
+                      << "    does not support layered 2D surfaces " << height
+                      << " pixels high." << endl;
+        }
+        height = ptr->maxSurface2DLayered[1];
+        returnSuccess = false;
+    }
+    if( layers > ptr->maxSurface2DLayered[2] )
+    {
+        if( returnSuccess && printWarn )
+        {
+            std::cerr << __FILE__ << ":" << __LINE__
+                      << ": CUDA device " << currentDevice << std::endl
+                      << "    does not support layered 2D surfaces " << layers
+                      << " pixels deep." << endl;
+        }
+        layers = ptr->maxSurface2DLayered[2];
+        returnSuccess = false;
+    }
+
+    return returnSuccess;
 }
 
 }}

--- a/src/popsift/common/device_prop.cu
+++ b/src/popsift/common/device_prop.cu
@@ -28,7 +28,7 @@ device_prop_t::device_prop_t( )
 
     _properties.resize(_num_devices);
 
-    for( int n=0; n<_num_devices; n++ ) {
+    for( int n=0; n<_num_devices; ++n ) {
         _properties[n] = new cudaDeviceProp;
         err = cudaGetDeviceProperties( _properties[n], n );
         POP_CUDA_FATAL_TEST( err, "Cannot get properties for a device" );

--- a/src/popsift/common/device_prop.h
+++ b/src/popsift/common/device_prop.h
@@ -16,12 +16,78 @@ class device_prop_t
 {
     int _num_devices;
     std::vector<cudaDeviceProp*> _properties;
+
+public:
+    enum {
+        do_warn = true,
+        dont_warn = false
+    };
+
 public:
     device_prop_t( );
     ~device_prop_t( );
 
     void print( );
     void set( int n, bool print_choice = false );
+
+    /** Check if a request exceeds the current CUDA device's limit in
+     *  texture2Dlinear dimensions. texture2Dlinear is based on CUDA memory that
+     *  can be accessed directly (i.e. no CudaArray).
+     * @param[in,out] width  Desired width of the texture.
+     * @param[in,out] height Desired height of the texture.
+     * @param[in]     printWarn if true, print warnings to cerr if desired width
+     *                          or height exceeds limits.
+     * @return { true if the desired width and height are possible.
+     *           false if one or both of the desired width and height are impossible.
+     *           The desired width or height (or both) are replaced by the limit.}
+     */
+    bool checkLimit_2DtexLinear( int& width, int& height, bool printWarn ) const;
+
+    /** Check if a request exceeds the current CUDA device's limit in
+     *  texture2D dimensions. texture2D is based on CUDA Arrays, which have
+     *  invisible layout and can only be filled with cudaMemcpy.
+     * @param[in,out] width  Desired width of the texture.
+     * @param[in,out] height Desired height of the texture.
+     * @param[in]     printWarn if true, print warnings to cerr if desired width
+     *                          or height exceeds limits.
+     * @return { true if the desired width and height are possible.
+     *           false if one or both of the desired width and height are impossible.
+     *           The desired width or height (or both) are replaced by the limit.}
+     */
+    bool checkLimit_2DtexArray( int& width, int& height, bool printWarn ) const;
+
+    /** Check if a request exceeds the current CUDA device's limit in
+     *  texture2DLayered dimensions. texture2DLayered refers to a 3D structure, where
+     *  interpolation happens only in 3D, effectively creating layers.
+     * @param[in,out] width  Desired width of the texture.
+     * @param[in,out] height Desired height of the texture.
+     * @param[in,out] layers Desired depth of the texture.
+     * @param[in]     printWarn if true, print warnings to cerr if desired width
+     *                          or height exceeds limits.
+     * @return { true if the desired width, height and depth are possible.
+     *           false if one or both of the desired width and height are impossible.
+     *           The desired width, height and layers are replaced by the limit
+     *           if they exceed it.}
+     */
+    bool checkLimit_2DtexLayered( int& width, int& height, int& layers,
+                                  bool printWarn ) const;
+
+    /** Check if a request exceeds the current CUDA device's limit in
+     *  surface2DLayered dimensions. surface2DLayered is the writable equivalent
+     *  to texture2DLayered, but the width must be given in bytes, not elements.
+     *  Since we use float, images cannot be as wide as expected.
+     * @param[in,out] width  Desired width of the texture.
+     * @param[in,out] height Desired height of the texture.
+     * @param[in,out] layers Desired depth of the texture.
+     * @param[in]     printWarn if true, print warnings to cerr if desired width
+     *                          or height exceeds limits.
+     * @return { true if the desired width, height and depth are possible.
+     *           false if one or both of the desired width and height are impossible.
+     *           The desired width, height and layers are replaced by the limit
+     *           if they exceed it.}
+     */
+    bool checkLimit_2DsurfLayered( int& width, int& height, int& layers,
+                                   bool printWarn ) const;
 };
 
 }}

--- a/src/popsift/popsift.cpp
+++ b/src/popsift/popsift.cpp
@@ -143,8 +143,7 @@ void PopSift::uninit( )
 PopSift::AllocTest PopSift::testTextureFit( int width, int height )
 {
     const bool warn = popsift::cuda::device_prop_t::dont_warn;
-    bool retval;
-    retval = _device_properties.checkLimit_2DtexLinear( width,
+    bool retval = _device_properties.checkLimit_2DtexLinear( width,
                                                         height,
                                                         warn );
     if( !retval )

--- a/src/popsift/popsift.cpp
+++ b/src/popsift/popsift.cpp
@@ -236,7 +236,7 @@ SiftJob* PopSift::enqueue( int                  w,
     {
         cerr << __FILE__ << ":" << __LINE__ << " Image too large" << endl
              << testTextureFitErrorString( a,w,h );
-        return NULL;
+        return nullptr;
     }
 
     SiftJob* job = new SiftJob( w, h, imageData );
@@ -260,7 +260,7 @@ SiftJob* PopSift::enqueue( int          w,
     {
         cerr << __FILE__ << ":" << __LINE__ << " Image too large" << endl
              << testTextureFitErrorString( a,w,h );
-        return NULL;
+        return nullptr;
     }
 
     SiftJob* job = new SiftJob( w, h, imageData );

--- a/src/popsift/popsift.cpp
+++ b/src/popsift/popsift.cpp
@@ -171,14 +171,8 @@ PopSift::AllocTest PopSift::testTextureFit( int width, int height )
                                                           height,
                                                           depth,
                                                           warn );
-    if( !retval )
-    {
-        return AllocTest::ImageExceedsLayeredSurfaceLimit;
-    }
-    else
-    {
-        return AllocTest::Ok;
-    }
+
+    return (retval ? AllocTest::Ok : AllocTest::ImageExceedsLayeredSurfaceLimit);
 }
 
 std::string PopSift::testTextureFitErrorString( AllocTest err, int width, int height )

--- a/src/popsift/popsift.cpp
+++ b/src/popsift/popsift.cpp
@@ -343,9 +343,12 @@ SiftJob::SiftJob( int w, int h, const unsigned char* imageData )
     _f = _p.get_future();
 
     _imageData = (unsigned char*)malloc( w*h );
-    if( _imageData != nullptr ) {
+    if( _imageData != nullptr )
+    {
         memcpy( _imageData, imageData, w*h );
-    } else {
+    }
+    else
+    {
         cerr << __FILE__ << ":" << __LINE__ << " Memory limitation" << endl
              << "E    Failed to allocate memory for SiftJob" << endl;
         exit( -1 );
@@ -360,9 +363,12 @@ SiftJob::SiftJob( int w, int h, const float* imageData )
     _f = _p.get_future();
 
     _imageData = (unsigned char*)malloc( w*h*sizeof(float) );
-    if( _imageData != nullptr ) {
+    if( _imageData != nullptr )
+    {
         memcpy( _imageData, imageData, w*h*sizeof(float) );
-    } else {
+    }
+    else
+    {
         cerr << __FILE__ << ":" << __LINE__ << " Memory limitation" << endl
              << "E    Failed to allocate memory for SiftJob" << endl;
         exit( -1 );

--- a/src/popsift/popsift.h
+++ b/src/popsift/popsift.h
@@ -15,6 +15,7 @@
 #include <thread>
 
 #include "common/sync_queue.h"
+#include "common/device_prop.h"
 #include "sift_conf.h"
 #include "sift_extremum.h"
 #include "sift_config.h"
@@ -96,6 +97,13 @@ public:
         FloatImages
     };
 
+    enum AllocTest
+    {
+        Ok,
+        ImageExceedsLinearTextureLimit,
+        ImageExceedsLayeredSurfaceLimit
+    };
+
 public:
 
     PopSift() = delete;
@@ -116,6 +124,43 @@ public:
     bool configure( const popsift::Config& config, bool force = false );
 
     void uninit( );
+
+    /** Check whether the current CUDA device can support the image
+     *  resolution (width,height) with the current configuration
+     *  based on the card's texture engine.
+     *  The function does not check if there is sufficient available
+     *  memory.
+     *  The first part of the test depends on the parameters width and
+     *  height. It checks whether the image size is supported by CUDA
+     *  2D linear textures on this card. This is used to load the image
+     *  into the first level of the first octave.
+     *  For the second part of the tst, two value of the configuration
+     *  are important: 
+     *  "downsampling", because it determines the required texture size
+     *  after loading. The CUDA 2D layered texture must support the
+     *  scaled width and height.
+     *  "levels", because it determines the number of levels in each
+     *  octave. The CUDA 2D layered texture must support enough depth
+     *  for each level.
+     * @param width  The width of the input image
+     * @param height The height of the input image
+     * @return AllocTest::Ok if the image dimensions are supported by this device's
+     *         CUDA texture engine,
+     *         AllocTest::ImageExceedsLinearTextureLimit if the input image size
+     *         exceeds the dimensions of the CUDA Texture used for loading.
+     *         The input image must be scaled.
+     *         AllocTest::ImageExceedsLayeredSurfaceLimit if the scaled input
+     *         image exceeds the dimensions of the CUDA Surface used for the
+     *         image pyramid. The scaling factor must be changes to fit in.
+     * @remark { If you want to call configure() before extracting features,
+     *           you should call configure() before textTextureFit(). }
+     * @remark { The current CUDA device is determined by a call to
+     *           cudaGetDevice(), card properties are only read once. }
+     */
+    AllocTest testTextureFit( int width, int height );
+
+    /** Create a warning string for an AllocTest error code. */
+    std::string testTextureFitErrorString( AllocTest err, int w, int h );
 
     /** Enqueue a byte image,  value range 0..255 */
     SiftJob*  enqueue( int                  w,
@@ -153,6 +198,7 @@ public:
 
 private:
     bool private_init( int w, int h );
+    void private_apply_scale_factor( int& w, int& h );
     void uploadImages( );
 
     /* The following method are alternative worker functions for Jobs submitted by
@@ -180,5 +226,8 @@ private:
 
     /// whether the object is initialized
     bool            _isInit{true};
+
+    // Device property collection runs when this object is created
+    popsift::cuda::device_prop_t   _device_properties;
 };
 


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description
Several recent bug reports are concerned with images that exceed the CUDA Texture size, but where PopSift just says "out of memory".


This PR adds a method testTextureFit() to class PopSift. This test can be called explicitly to test whether PopSift can be used for a given image and downscale factor, but even if it is not called explicitly, it is called during enqueue(). If an exceeded texture size is detected during enqueue(), NULL will be returned and a multi-line error string is printed on cerr to explain the error (because there are 2 different limits: (linear texture for image loading and layered texture for DoG pyramid creation).

The PR adds also the method testTextureFitErrorString() to get the multi-line explanation as a string for the caller's own purposes.

## Features list
New method PopSift::testTextureFit.
New method PopSift::testTextureFitErrorString.

Provides explanations and hints for errors #77 and #88.

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks
PopSift::enqueue changes behaviour. It can now return NULL if it will be impossible to process the given image size.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
