### PR TITLE
Remove stale function that's not defined.

### DIFF
--- a/src/popsift/sift_conf.h
+++ b/src/popsift/sift_conf.h
@@ -111,7 +111,6 @@ struct Config
     void setMaxExtreme( int m );
     void setPrintGaussTables( );
     void setDPOrientation( bool on );
-    void setMaxExtrema( int extrema );
     void setFilterMaxExtrema( int extrema );
     void setFilterGridSize( int sz );
     void setFilterSorting( const std::string& direction );


### PR DESCRIPTION
## Description
This PR removes the `setMaxExtrema()` config function because it's not defined. As far as I can tell, the removed function is an unused alias for `setFilterMaxExtrema()`.

