### PR TITLE
Dev/fix testing paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,9 @@ option(PopSift_ERRCHK_AFTER_KERNEL     "Synchronize and check CUDA error after e
 option(PopSift_USE_POSITION_INDEPENDENT_CODE "Generate position independent code." ON)
 option(PopSift_USE_GRID_FILTER "Switch off grid filtering to massively reduce compile time while debugging other things." ON)
 option(PopSift_USE_NORMF "The __normf function computes Euclidean distance on large arrays. Fast but stability is uncertain." OFF)
-option(PopSift_USE_TEST_CMD "Add testing step for functional verification" OFF)
 option(PopSift_NVCC_WARNINGS "Switch on several additional warning for CUDA nvcc" OFF)
+option(PopSift_USE_TEST_CMD "Add testing step for functional verification" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
-
 
 if(PopSift_USE_POSITION_INDEPENDENT_CODE AND NOT MSVC)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -201,7 +200,13 @@ endif()
 
 add_subdirectory(src)
 
+set(PopSift_TESTFILE_PATH "../../GIT/popsift-samples/datasets/sample/big_set/" CACHE STRING "Base directory where your test files are stored")
 if(PopSift_USE_TEST_CMD)
+  if(NOT IS_ABSOLUTE("${PopSift_TESTFILE_PATH}"))
+    get_filename_component(PopSift_TESTFILES "${PopSift_TESTFILE_PATH}" ABSOLUTE)
+    set(PopSift_TESTFILE_PATH "${PopSift_TESTFILES}")
+  endif()
+
   add_subdirectory(testScripts)
 endif()
 
@@ -228,9 +233,12 @@ message(STATUS "Generate position independent code: " ${CMAKE_POSITION_INDEPENDE
 message(STATUS "Use CUDA NVTX for profiling: " ${PopSift_USE_NVTX_PROFILING})
 message(STATUS "Synchronize and check CUDA error after every kernel: " ${PopSift_ERRCHK_AFTER_KERNEL})
 message(STATUS "Grid filtering: " ${PopSift_USE_GRID_FILTER})
-message(STATUS "Testing step: " ${PopSift_USE_TEST_CMD})
 message(STATUS "Additional warning for CUDA nvcc: " ${PopSift_NVCC_WARNINGS})
 message(STATUS "Compiling for CUDA CCs: ${PopSift_CUDA_CC_LIST}")
 message(STATUS "Install path: " ${CMAKE_INSTALL_PREFIX})
+message(STATUS "Testing step: " ${PopSift_USE_TEST_CMD})
+if(PopSift_USE_TEST_CMD)
+  message(STATUS "Path for test input: " ${PopSift_TESTFILE_PATH})
+endif()
 message("\n******************************************")
 message("\n")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ endif()
 
 add_subdirectory(src)
 
-set(PopSift_TESTFILE_PATH "../../GIT/popsift-samples/datasets/sample/big_set/" CACHE STRING "Base directory where your test files are stored")
+set(PopSift_TESTFILE_PATH "popsift-samples/datasets/sample/big_set/" CACHE STRING "Base directory where your test files are stored")
 if(PopSift_USE_TEST_CMD)
   if(NOT IS_ABSOLUTE("${PopSift_TESTFILE_PATH}"))
     get_filename_component(PopSift_TESTFILES "${PopSift_TESTFILE_PATH}" ABSOLUTE)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ PopSift tries to stick as closely as possible to David Lowe's famous paper [1], 
 
 PopSift compiles and works with NVidia cards of compute capability >= 3.0 (including the GT 650M), but the code is developed with the compute capability 5.2 card GTX 980 Ti in mind.
 
+CUDA SDK 11 does no longer support compute capability 3.0. 3.5 is still supported with deprecation warning.
+
 ## Dependencies
 
 PopSift depends on:

--- a/testScripts/CMakeLists.txt
+++ b/testScripts/CMakeLists.txt
@@ -5,7 +5,7 @@ configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/testOxfordDataset.sh.in
                 ${CMAKE_CURRENT_BINARY_DIR}/testOxfordDataset.sh )
 
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/TEST.sh.in
-				${CMAKE_CURRENT_BINARY_DIR}/TEST.sh )
+                ${CMAKE_CURRENT_BINARY_DIR}/TEST.sh )
 
 add_custom_target(
 	prepare-test

--- a/testScripts/TEST.sh.in
+++ b/testScripts/TEST.sh.in
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-# IMAGE=../../popsift-samples/sample/big_set/boat/img2.ppm
-IMAGE=../../popsift-samples/sample/big_set/boat/img3.ppm
-# IMAGE=./test-17x17.pgm
+IMAGE=@PopSift_TESTFILE_PATH@/boat/img3.ppm
 
-POPSIFT_DEMO_BIN=@EXECUTABLE_OUTPUT_PATH@/popsift-demo
+POPSIFT_DEMO_BIN=@CMAKE_BINARY_DIR@/@CMAKE_SYSTEM_NAME@-@CMAKE_SYSTEM_PROCESSOR@/popsift-demo
 
 LOG=--log
 # LOG=
@@ -18,8 +16,8 @@ FILTER="--filter-max-extrema=2000 --filter-grid=2 --filter-sort=down"
 
 PARAMS="$LOG $GAUSS_MODE $SCALING $FILTER --popsift-mode --octaves=8 --threshold=0.04 --edge-threshold=10.0 --initial-blur=0.5"
 
-for mode in loop ; do
-# for mode in loop grid igrid notile ; do
+# for mode in loop ; do
+for mode in loop grid igrid notile ; do
 # for mode in igrid notile ; do
   echo "MODE: $mode"
   echo "$POPSIFT_DEMO_BIN $PARAMS --desc-mode=$mode --write-as-uchar --norm-multi=9 -i $IMAGE"

--- a/testScripts/TEST.sh.in
+++ b/testScripts/TEST.sh.in
@@ -2,7 +2,7 @@
 
 IMAGE=@PopSift_TESTFILE_PATH@/boat/img3.ppm
 
-POPSIFT_DEMO_BIN=@CMAKE_BINARY_DIR@/@CMAKE_SYSTEM_NAME@-@CMAKE_SYSTEM_PROCESSOR@/popsift-demo
+POPSIFT_DEMO_BIN=@CMAKE_RUNTIME_OUTPUT_DIRECTORY@/popsift-demo
 
 LOG=--log
 # LOG=
@@ -71,4 +71,3 @@ echo -n "grid vs notile:  "
 echo -n "igrid vs notile: "
 ~/GIT/github/popsift-samples/playground/build/compare-descfiles \
 	-q output-features-igrid.txt output-features-notile.txt
-

--- a/testScripts/testOxfordDataset.sh.in
+++ b/testScripts/testOxfordDataset.sh.in
@@ -45,7 +45,7 @@ do
       echo "Directory output-$img exists. Skipping."
       continue
     fi
-    @CMAKE_BINARY_DIR@/@CMAKE_SYSTEM_NAME@-@CMAKE_SYSTEM_PROCESSOR@/popsift-demo --log --gauss-mode vlfeat --desc-mode loop --popsift-mode --root-sift --downsampling -1 -i $imgfile
+    @CMAKE_RUNTIME_OUTPUT_DIRECTORY@/popsift-demo --log --gauss-mode vlfeat --desc-mode loop --popsift-mode --root-sift --downsampling -1 -i $imgfile
     if [ $? != 0 ]
     then
       echo "Running popsift on $imgfile failed."
@@ -157,4 +157,3 @@ do
     fi
   done
 done
-

--- a/testScripts/testOxfordDataset.sh.in
+++ b/testScripts/testOxfordDataset.sh.in
@@ -30,12 +30,12 @@ do
   cd $dataset
   for img in img1 img2 img3 img4 img5 img6
   do
-    if [ -f @CMAKE_SOURCE_DIR@/oxford/$dataset/$img.pgm ]
+    if [ -f @PopSift_TESTFILE_PATH@/$dataset/$img.pgm ]
     then
-      imgfile=@CMAKE_SOURCE_DIR@/oxford/$dataset/$img.pgm
-    elif [ -f @CMAKE_SOURCE_DIR@/oxford/$dataset/$img.ppm ]
+      imgfile=@PopSift_TESTFILE_PATH@/$dataset/$img.pgm
+    elif [ -f @PopSift_TESTFILE_PATH@/$dataset/$img.ppm ]
     then
-      imgfile=@CMAKE_SOURCE_DIR@/oxford/$dataset/$img.ppm
+      imgfile=@PopSift_TESTFILE_PATH@/$dataset/$img.ppm
     else
       continue
     fi
@@ -45,7 +45,7 @@ do
       echo "Directory output-$img exists. Skipping."
       continue
     fi
-    @EXECUTABLE_OUTPUT_PATH@/popsift-demo --log --gauss-mode vlfeat --desc-mode loop --popsift-mode --root-sift --downsampling -1 -i $imgfile
+    @CMAKE_BINARY_DIR@/@CMAKE_SYSTEM_NAME@-@CMAKE_SYSTEM_PROCESSOR@/popsift-demo --log --gauss-mode vlfeat --desc-mode loop --popsift-mode --root-sift --downsampling -1 -i $imgfile
     if [ $? != 0 ]
     then
       echo "Running popsift on $imgfile failed."


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

PopSift should get a real testsuite at some point, but up to now, the testScripts/TEST.sh is the shell script that is manipulated to compare different PopSift options.

It has so far used a hardcoded path for the test dataset and an outdated macro for the path of the popsift-demo executable, needing manual fixing every time. This PR updates the path for popsift-demo and makes the dataset path configurable throught cmake commandline or ccmake.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
