### PR TITLE
[bug] pair malloc with free, not delete

### DIFF
--- a/src/popsift/popsift.cpp
+++ b/src/popsift/popsift.cpp
@@ -380,7 +380,7 @@ SiftJob::SiftJob( int w, int h, const float* imageData )
 
 SiftJob::~SiftJob( )
 {
-    delete [] _imageData;
+    free( _imageData );
 }
 
 void SiftJob::setImg( popsift::ImageBase* img )


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Bug #107 found memory allocated with malloc but released with delete. Changed to free since platforms exist where the two are not interchangeable.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks


<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
