### PR TITLE
Pass correct shared memory size to orientation kernel

### DIFF
--- a/src/popsift/s_orientation.cu
+++ b/src/popsift/s_orientation.cu
@@ -411,7 +411,7 @@ void Pyramid::orientation( const Config& conf )
             grid.x  = num;
 
             ori_par
-                <<<grid,block,0,oct_str>>>
+                <<<grid,block,4*64*sizeof(float),oct_str>>>
                 ( octave,
                   hct.ext_ps[octave],
                   oct_obj.getDataTexPoint( ),

--- a/src/popsift/sift_pyramid.cu
+++ b/src/popsift/sift_pyramid.cu
@@ -290,7 +290,7 @@ FeaturesHost* Pyramid::get_descriptors( const Config& conf )
     nvtxRangePushA( "download descriptors" );
     FeaturesHost* features = new FeaturesHost( hct.ext_total, hct.ori_total );
 
-    if( hct.ext_total == 0 )
+    if( hct.ext_total == 0 || hct.ori_total == 0 )
     {
         nvtxRangePop();
         return features;


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

cuda-memcheck failed in the kernel ori_par when PopSift was built in Debug mode. This happened on a GTX 1080 both with CUDA 11.0 and 10.2. Release mode worked without any problems.

The origin of the problem is that the kernel ori_par was started with the third kernel parameter, shared memory size, set to zero, although the kernel uses 4 shared arrays. Furthermore, some of the arrays were 36x4 bytes long. 

## Features list
Extending the array sizes to 64x4 bytes and starting the kernel with 4x64x4 bytes of shared memory fixed the bug.

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->


## Implementation remarks

Some code simplifications were possible because of the well-aligned array sizes.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
