### PR TITLE
Feature/compare scripts2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CMake: support for cuda 11 [PR](https://github.com/alicevision/popsift/pull/103)
 - Support for Cuda CC 7 cards (RTX 2080) [PR](https://github.com/alicevision/popsift/pull/67)
 - Support for Boost 1.70 [PR](https://github.com/alicevision/popsift/pull/65)
+- Test: adding descriptor comparator [PR](https://github.com/alicevision/popsift/pull/115)
 
 ### Fixed
 - CMake: fixes to allow building on Windows using vcpkg [PR](https://github.com/alicevision/popsift/pull/92)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ else()
   message(STATUS "Building in ${CMAKE_BUILD_TYPE} configuration")
 endif()
 
+include(FindOpenACC)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenACC_CXX_FLAGS}")
+
 # ensure the proper linker flags when building the static version on MSVC
 if(MSVC AND NOT BUILD_SHARED_LIBS)
   foreach(config "DEBUG" "RELEASE" "MINSIZEREL" "RELWITHDEBINFO")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ CUDA_ADD_LIBRARY(popsift
         popsift/s_desc_grid.cu popsift/s_desc_grid.h
         popsift/s_desc_igrid.cu popsift/s_desc_igrid.h
         popsift/s_desc_notile.cu popsift/s_desc_notile.h
+        popsift/s_desc_vlfeat.cu popsift/s_desc_vlfeat.h
         popsift/s_desc_norm_rs.h
         popsift/s_desc_norm_l2.h
         popsift/s_desc_normalize.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -150,3 +150,7 @@ if(PopSift_BUILD_EXAMPLES)
   add_subdirectory(application)
 endif()
 
+if(PopSift_USE_TEST_CMD)
+  add_subdirectory(compareSiftFiles)
+endif()
+

--- a/src/compareSiftFiles/CMakeLists.txt
+++ b/src/compareSiftFiles/CMakeLists.txt
@@ -1,0 +1,38 @@
+if(NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  # I am top-level project, i.e. I am not being include by another project
+  cmake_minimum_required(VERSION 3.12)
+  project(PopSiftCompareDescriptors LANGUAGES CXX)
+
+  include(GNUInstallDirs)
+
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+if(PopSift_BOOST_USE_STATIC_LIBS)
+  set(Boost_USE_STATIC_LIBS ON)
+endif()
+find_package(Boost 1.53.0 REQUIRED COMPONENTS filesystem program_options system)
+if(WIN32)
+  add_definitions("-DBOOST_ALL_NO_LIB")
+endif(WIN32)
+
+#############################################################
+# compareSiftFiles
+#############################################################
+
+add_executable(popsift-compareSiftFiles
+               compareSiftFiles.cpp
+               csf_feat.cpp csf_feat.h
+	       csf_options.cpp csf_options.h)
+
+target_include_directories(popsift-compareSiftFiles PUBLIC ${Boost_INCLUDE_DIRS})
+target_link_libraries(popsift-compareSiftFiles PUBLIC ${Boost_LIBRARIES})
+
+set_property(TARGET popsift-compareSiftFiles PROPERTY CXX_STANDARD 11)
+
+#############################################################
+# installation
+#############################################################
+
+install(TARGETS popsift-compareSiftFiles DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/compareSiftFiles/compareSiftFiles.cpp
+++ b/src/compareSiftFiles/compareSiftFiles.cpp
@@ -1,0 +1,110 @@
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <sstream>
+#include <cmath>
+#include <vector>
+#include <algorithm>
+#include <cstring>
+
+#include <boost/program_options.hpp>
+
+#include "csf_feat.h"
+#include "csf_options.h"
+
+using namespace std;
+
+typedef vector<float> desc_t;
+
+void readFile( vector<feat_t>& vec, const std::string& filename );
+
+int main( int argc, char* argv[] )
+{
+    Parameters param;
+
+    parseargs( argc, argv, param );
+
+    vector<feat_t> l_one;
+    vector<feat_t> l_two;
+
+    readFile( l_one, param.input[0] );
+    readFile( l_two, param.input[1] );
+
+    ostream* outfile = &cout;
+    if( ! param.outfile_name.empty() )
+    {
+        ostream* o = new ofstream( param.outfile_name );
+        if( o->good() )
+        {
+            outfile = o;
+        }
+    }
+
+    ostream* descfile = 0;
+    if( ! param.descfile_name.empty() )
+    {
+        ostream* o = new ofstream( param.descfile_name );
+        if( o->good() )
+        {
+            descfile = o;
+        }
+    }
+
+    int len = l_one.size();
+    int ct = 0;
+    float nextpercent = 10;
+
+    vector<float> desc_stats( 128, 0.0f );
+
+    for( auto l : l_one )
+    {
+        ostream* print_dists = param.descfile_verbose ? descfile : 0;
+
+        l.compareBestMatch( *outfile, print_dists, l_two, desc_stats, param.briefinfo );
+        ct++;
+        if( float(ct * 100) / len >= float(nextpercent) )
+        {
+            cerr << nextpercent << "% " <<  ct << endl;
+            nextpercent += 10;
+        }
+    }
+
+    if( descfile )
+    {
+        int sz = l_one.size();
+        (*descfile) << "========== Summary Stats ==========" << endl
+                    << "Average values:" << endl
+                    << setprecision(3);
+        for( int i=0; i<128; i++ )
+        {
+            if( i%32==0  ) (*descfile) << "X=0 | ";
+            if( i%32==8  ) (*descfile) << "X=1 |  ";
+            if( i%32==16 ) (*descfile) << "X=2 |   ";
+            if( i%32==24 ) (*descfile) << "X=3 |    ";
+            desc_stats[i] /= sz;
+            (*descfile) << setw(8) << desc_stats[i] << " ";
+            if( i%8==7 ) (*descfile) << endl;
+        }
+        (*descfile) << endl;
+    }
+
+    if( ! param.outfile_name.empty() )
+    {
+        delete outfile;
+    }
+}
+
+void readFile( vector<feat_t>& vec, const std::string& filename )
+{
+    ifstream infile( filename );
+
+    if( ! infile.good() )
+    {
+        cerr << "File " << filename << " is not open." << endl;
+        exit( -1 );
+    }
+
+    int lines_read = readFeats( vec, infile );
+    cerr << "Read " << lines_read << " lines from " << filename << endl;
+}
+

--- a/src/compareSiftFiles/csf_feat.cpp
+++ b/src/compareSiftFiles/csf_feat.cpp
@@ -1,0 +1,191 @@
+#include <sstream>
+#include <cmath>
+#include <algorithm>
+
+#include "csf_feat.h"
+
+using namespace std;
+
+const float M_PI2 = 2.0f * 3.14159265358979323846f;
+
+bool feat_t::_use_l2_distance = true;
+
+int readFeats( vector<feat_t>& l_one, ifstream& f_one )
+{
+    char buffer[1024];
+    int  lines_read;
+    
+    lines_read = 0;
+    while( f_one.good() )
+    {
+        f_one.getline( buffer, 1024 );
+        if( f_one.good() )
+        {
+            bool success = addFeat( l_one, buffer );
+            if( success )
+            {
+                lines_read++;
+            }
+        }
+    }
+    return lines_read;
+}
+
+bool addFeat( vector<feat_t>& features, char* line )
+{
+    vector<float> values(5+128); // 4 or 5 values followed by 128 desc values
+
+    int i = 0;
+    istringstream s( line );
+    while( s >> values[i] )
+    {
+        i++;
+    }
+
+    // cerr << "Found " << i << " floats in line" << endl;
+    features.emplace_back( i, values );
+
+    if( i == 0 ) return false;
+    return true;
+}
+
+feat_t::feat_t( int num, const vector<float>& input )
+    : desc(128)
+{
+    auto it = input.begin();
+    auto to = desc.begin();
+    if( num == 132 )
+    {
+        x     = *it++;
+        y     = *it++;
+        sigma = *it++;
+        ori   = *it++;
+        for( int i=0; i<128; i++ ) *to++ = *it++;
+    }
+    else if( num == 133 )
+    {
+        float odbss;
+        x     = *it++;
+        y     = *it++;
+        odbss = *it++;
+        sigma = odbss == 0.0f ? 0.0f : sqrtf( 1.0f / odbss );
+        ori   = 0.0f;
+        it++;
+        it++;
+        for( int i=0; i<128; i++ ) *to++ = *it++;
+    }
+    else
+    {
+        cerr << "The keypoint line contains an unexpected number of floats (" << num << ")" << endl;
+        return;
+    }
+}
+
+void feat_t::print( ostream& ostr ) const
+{
+    ostr << "(" << x << "," << y << ")";
+    ostr << " sigma=" << sigma << " ori=" << ori;
+    for( auto it : desc )
+    {
+        ostr << " " << it;
+    }
+}
+
+void feat_t::compareBestMatch( ostream& ostr, ostream* dstr, const vector<feat_t>& l_one, vector<float>& desc_stats,  bool minOnly ) const
+{
+    vector<float> distances;
+    distances.reserve( l_one.size() );
+
+    if( !minOnly ) ostr << "==========" << endl;
+    for( auto r : l_one )
+    {
+        float v = dist( r );
+        distances.push_back( v );
+    }
+
+    auto it = distances.begin();
+
+    auto m = min_element( distances.begin(), distances.end() );
+
+    float second = INFINITY;
+
+    for( auto r : l_one )
+    {
+        if( minOnly )
+        {
+            if( it == m )
+            {
+                ostr << "desc dist " << *it
+                     << " MIN"
+                     << " pixdist " << sqrtf( (x-r.x)*(x-r.x) + (y-r.y)*(y-r.y) )
+                     << " angledist " << fabsf( ori/M_PI2*360.0f - r.ori/M_PI2*360.0f );
+
+                if( dstr )
+                {
+                    auto left  = desc.begin();
+                    auto right = r.desc.begin();
+                    for( int i=0; i<128; i++, left++, right++ )
+                    {
+                        float diff = *left - *right;
+                        (*dstr) << diff << " ";
+                        desc_stats[i] += diff;
+                    }
+                    (*dstr) << endl;
+                }
+            }
+            else if( *it > *m )
+            {
+                second = min<float>( second, *it );
+            }
+            it++;
+        }
+        else
+        {
+            ostr << "desc dist " << *it;
+            if( it == m )
+                ostr << " MIN ";
+            else
+                ostr << "     ";
+            it++;
+            ostr << " pixdist " << sqrtf( (x-r.x)*(x-r.x) + (y-r.y)*(y-r.y) )
+                 << " angledist " << fabsf( ori/M_PI2*360.0f - r.ori/M_PI2*360.0f )
+                 << endl;
+        }
+    }
+    if( minOnly )
+    {
+        ostr << " 2best " << second << endl;
+    }
+}
+
+float feat_t::dist( const feat_t& r ) const
+{
+    if( _use_l2_distance )
+    {
+        float sum = 0.0f;
+        auto it_r = r.desc.begin();
+        for( auto l : desc )
+        {
+            float val = l - *it_r++;
+            sum += ( val * val );
+        }
+        return sqrtf( sum );
+    }
+    else
+    {
+        float sum = 0.0f;
+        auto it_r = r.desc.begin();
+        for( auto l : desc )
+        {
+            float val = l - *it_r++;
+            sum += fabsf( val );
+        }
+        return sum / 128;
+    }
+}
+
+void feat_t::setL2Distance( bool onoff )
+{
+    _use_l2_distance = onoff;
+}
+

--- a/src/compareSiftFiles/csf_feat.h
+++ b/src/compareSiftFiles/csf_feat.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+
+typedef std::vector<float> desc_t;
+
+class feat_t
+{
+    static bool _use_l2_distance;
+
+public:
+    float  x;
+    float  y;
+    float  sigma;
+    float  ori;
+    desc_t desc;
+
+    feat_t( int num, const std::vector<float>& input );
+
+    void print( std::ostream& ostr ) const;
+
+    void compareBestMatch( std::ostream&              ostr,
+                           std::ostream*              dstr,
+                           const std::vector<feat_t>& l_one,
+                           std::vector<float>&        desc_stats,
+                           bool                       minOnly ) const;
+
+    static void setL2Distance( bool onoff );
+
+private:
+    float dist( const feat_t& r ) const;
+};
+
+int readFeats( std::vector<feat_t>& l_one,
+               std::ifstream&       f_one );
+bool addFeat( std::vector<feat_t>& features, char* line );
+

--- a/src/compareSiftFiles/csf_options.cpp
+++ b/src/compareSiftFiles/csf_options.cpp
@@ -1,0 +1,96 @@
+#include <iostream>
+
+#include <boost/program_options.hpp>
+
+#include "csf_options.h"
+
+using namespace std;
+
+void parseargs( int argc, char** argv, Parameters& param )
+{
+    using namespace boost::program_options;
+
+    positional_options_description positional;
+    positional.add( "input", -1 );
+
+    options_description hidden_options("Hidden options");
+    options_description options("Options");
+
+    {
+        hidden_options.add_options()
+            ("input,i",   value<vector<string> >()->multitoken()->composing(),
+                          "A descriptor file. 2 descriptor files must be passed");
+
+        options.add_options()
+            ("help,h", "Print usage")
+            ("verbose,v", value<bool>( &param.briefinfo )->default_value(false),
+                          "verbose, longer output")
+            ("output,o",  value<std::string>(&param.outfile_name),
+                          "print essential diff info to <file> (default is cout)")
+            ("desc,d",    value<std::string>(&param.descfile_name),
+                          "print descriptor distance per cell to <file>")
+            ("dv",        value<bool>(&param.descfile_verbose)->default_value(false),
+                          "prints every comparison into descfile, instead of summary only")
+            ("l1",        bool_switch()->notifier( [&](bool b)
+                                                   {
+                                                       feat_t::setL2Distance( !b );
+                                                   } )
+                                       ->default_value( false ),
+                          "use L1 for distance computation instead of L2" )
+            ;
+    }
+
+    options_description all("Allowed options");
+
+    all.add(hidden_options)
+       .add(options);
+
+    variables_map vm;
+
+    try
+    {
+
+        store( command_line_parser(argc, argv).options( all )
+                                              .positional( positional )
+                                              .run( ),
+                vm );
+
+        param.input = vm["input"].as<vector<string> >();
+
+        if( vm.count("help") )
+        {
+            usage( argv[0], options );
+            exit(EXIT_SUCCESS);
+        }
+
+        if( param.input.size() != 2 )
+        {
+            cerr << "Error: Exactly 2 input file for comparison must be provided." << endl;
+            usage( argv[0], options );
+            exit(EXIT_FAILURE);
+        }
+
+        notify(vm); // Notify does processing (e.g., raise exceptions if required args are missing)
+    }
+    catch(boost::program_options::error& e)
+    {
+        std::cerr << "Error: " << e.what() << std::endl << std::endl;
+        usage( argv[0], options );
+        exit(EXIT_FAILURE);
+    }
+}
+
+void usage( char* name, const boost::program_options::options_description& options )
+{
+    cerr << endl
+         << "Usage: " << name << " [Options] <descriptorfile> <descriptorfile>" << endl
+         << endl
+         << "Description\n"
+            "    Compute the L1 or L2 distance between the descriptors of closest\n"
+            "    coordinate pairs.\n"
+            "    When a coordinate has several orientations, the closest distance\n"
+            "    is reported. Summary information at the end." << endl
+         << endl
+         << options << endl;
+}
+

--- a/src/compareSiftFiles/csf_options.h
+++ b/src/compareSiftFiles/csf_options.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <boost/program_options.hpp>
+
+#include "csf_feat.h"
+
+struct Parameters
+{
+    std::vector<std::string> input;
+    std::string              outfile_name;
+    std::string              descfile_name;
+    bool                     descfile_verbose;
+    bool                     briefinfo;
+};
+
+void parseargs( int argc, char** argv, Parameters& param );
+void usage( char* name, const boost::program_options::options_description& all );
+

--- a/src/popsift/features.cu
+++ b/src/popsift/features.cu
@@ -107,16 +107,16 @@ void FeaturesHost::unpin( )
     cudaHostUnregister( _ori );
 }
 
-void FeaturesHost::print( std::ostream& ostr, bool write_as_uchar ) const
+void FeaturesHost::print( std::ostream& ostr, bool write_as_uchar, bool with_orientation ) const
 {
     for( int i=0; i<size(); i++ ) {
-        _ext[i].print( ostr, write_as_uchar );
+        _ext[i].print( ostr, write_as_uchar, with_orientation );
     }
 }
 
 std::ostream& operator<<( std::ostream& ostr, const FeaturesHost& feature )
 {
-    feature.print( ostr, false );
+    feature.print( ostr, false, false );
     return ostr;
 }
 
@@ -304,13 +304,30 @@ void FeaturesDev::match( FeaturesDev* other )
  * Feature
  *************************************************************/
 
-void Feature::print( std::ostream& ostr, bool write_as_uchar ) const
+void Feature::print( std::ostream& ostr, bool write_as_uchar, bool with_orientation ) const
 {
     float sigval =  1.0f / ( sigma * sigma );
 
     for( int ori=0; ori<num_ori; ori++ ) {
-        ostr << xpos << " " << ypos << " "
-             << sigval << " 0 " << sigval << " ";
+        if( with_orientation )
+        {
+            float dom_ori = orientation[ori];
+            // dom_ori = dom_ori / M_PI2 * 360;
+            // if (dom_ori < 0) dom_ori += 360;
+            if (dom_ori < 0) dom_ori += M_PI2;
+
+            ostr << std::setprecision(6)
+                 << xpos << " " << ypos << " "
+                 << sigma << " "
+                 << dom_ori << " ";
+        }
+        else
+        {
+            ostr << std::setprecision(6)
+                 << xpos << " " << ypos << " "
+                 << sigval << " 0 "
+                 << sigval << " ";
+        }
         if( write_as_uchar ) {
             for( int i=0; i<128; i++ ) {
                 ostr << roundf(desc[ori]->features[i]) << " ";
@@ -328,7 +345,7 @@ void Feature::print( std::ostream& ostr, bool write_as_uchar ) const
 
 std::ostream& operator<<( std::ostream& ostr, const Feature& feature )
 {
-    feature.print( ostr, false );
+    feature.print( ostr, false, false );
     return ostr;
 }
 

--- a/src/popsift/features.h
+++ b/src/popsift/features.h
@@ -33,7 +33,7 @@ struct Feature
     float       orientation[ORIENTATION_MAX_COUNT];
     Descriptor* desc[ORIENTATION_MAX_COUNT];
 
-    void print( std::ostream& ostr, bool write_as_uchar ) const;
+    void print( std::ostream& ostr, bool write_as_uchar, bool with_orientation ) const;
 };
 
 std::ostream& operator<<( std::ostream& ostr, const Feature& feature );
@@ -91,7 +91,7 @@ public:
     inline Feature*    getFeatures()    { return _ext; }
     inline Descriptor* getDescriptors() { return _ori; }
 
-    void print( std::ostream& ostr, bool write_as_uchar ) const;
+    void print( std::ostream& ostr, bool write_as_uchar, bool with_orientation ) const;
 
 protected:
     friend class Pyramid;

--- a/src/popsift/s_desc_norm_l2.h
+++ b/src/popsift/s_desc_norm_l2.h
@@ -58,15 +58,15 @@ void NormalizeL2::normalize( const float* src_desc, float* dst_desc, const bool 
     float norm;
 
     if( threadIdx.x == 0 ) {
-        norm = normf( 128, src_desc );
+        norm = rnormf( 128, src_desc ); // 1/sqrt(sum of squares)
     }
     __syncthreads();
     norm = popsift::shuffle( norm, 0 );
 
-    descr.x = min( descr.x, 0.2f*norm );
-    descr.y = min( descr.y, 0.2f*norm );
-    descr.z = min( descr.z, 0.2f*norm );
-    descr.w = min( descr.w, 0.2f*norm );
+    descr.x = min( descr.x*norm, 0.2f );
+    descr.y = min( descr.y*norm, 0.2f );
+    descr.z = min( descr.z*norm, 0.2f );
+    descr.w = min( descr.w*norm, 0.2f );
 
     norm = descr.x * descr.x
          + descr.y * descr.y
@@ -96,14 +96,14 @@ void NormalizeL2::normalize( const float* src_desc, float* dst_desc, const bool 
     norm += popsift::shuffle_down( norm,  2 );
     norm += popsift::shuffle_down( norm,  1 );
     if( threadIdx.x == 0 ) {
-        norm = __fsqrt_rn( norm );
+        norm = __frsqrt_rn( norm );
     }
     norm = popsift::shuffle( norm,  0 );
 
-    descr.x = min( descr.x, 0.2f*norm );
-    descr.y = min( descr.y, 0.2f*norm );
-    descr.z = min( descr.z, 0.2f*norm );
-    descr.w = min( descr.w, 0.2f*norm );
+    descr.x = min( descr.x*norm, 0.2f );
+    descr.y = min( descr.y*norm, 0.2f );
+    descr.z = min( descr.z*norm, 0.2f );
+    descr.w = min( descr.w*norm, 0.2f );
 
     norm = descr.x * descr.x
          + descr.y * descr.y

--- a/src/popsift/s_desc_normalize.h
+++ b/src/popsift/s_desc_normalize.h
@@ -18,17 +18,17 @@ void normalize_histogram( )
     Descriptor* descs            = dbuf.desc;
     const int   num_orientations = dct.ori_total;
 
-    int offset = blockIdx.x * 32 + threadIdx.y;
+    int offset = blockIdx.x * blockDim.y + threadIdx.y;
 
     // all of these threads are useless
-    if( blockIdx.x * 32 >= num_orientations ) return;
+    if( blockIdx.x * blockDim.y >= num_orientations ) return;
 
-    offset = ( offset < num_orientations ) ? offset
-                                           : num_orientations-1;
-    Descriptor* desc = &descs[offset];
+    offset = min( offset, num_orientations-1 );
+
+    float* features = descs[offset].features;
 
     bool ignoreme = ( offset >= num_orientations );
 
-    T::normalize( desc->features, ignoreme );
+    T::normalize( features, ignoreme );
 }
 

--- a/src/popsift/s_desc_vlfeat.cu
+++ b/src/popsift/s_desc_vlfeat.cu
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2016-2017, Simula Research Laboratory
+ *           2018-2020, University of Oslo
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "common/assist.h"
+#include "common/debug_macros.h"
+#include "common/vec_macros.h"
+#include "s_desc_vlfeat.h"
+#include "s_gradiant.h"
+#include "sift_constants.h"
+#include "sift_pyramid.h"
+
+#include <cstdio>
+
+using namespace popsift;
+
+__device__ static inline
+void ext_desc_vlfeat_sub( const float         ang,
+                          const Extremum*     ext,
+                          float* __restrict__ features,
+                          cudaTextureObject_t layer_tex,
+                          const int           width,
+                          const int           height )
+{
+    const float x     = ext->xpos;
+    const float y     = ext->ypos;
+    const int   level = ext->lpos; // old_level;
+    const float sig   = ext->sigma;
+    const float SBP   = fabsf(DESC_MAGNIFY * sig);
+
+    if( SBP == 0 ) {
+        return;
+    }
+
+    float cos_t;
+    float sin_t;
+    __sincosf( ang, &sin_t, &cos_t );
+
+    const float csbp  = cos_t * SBP;
+    const float ssbp  = sin_t * SBP;
+    const float crsbp = cos_t / SBP;
+    const float srsbp = sin_t / SBP;
+
+    // We have 4x4*16 bins.
+    // There centers have the offsets -1.5, -0.5, 0.5, 1.5 from the
+    // keypoint. The points that support them stretch from -2 to 2
+    const float2 maxdist = make_float2( -2.0f, -2.0f );
+
+    // We rotate the corner of the maximum range by the keypoint orientation.
+    const float ptx = fabsf( ::fmaf( csbp, maxdist.x, ::fmaf( -ssbp, maxdist.y, x )) );
+    const float pty = fabsf( ::fmaf( csbp, maxdist.y, ::fmaf(  ssbp, maxdist.x, y ) ) );
+
+    const float bsz = fabsf(csbp) + fabsf(ssbp);
+    const int   xmin = max(1,          (int)floorf(x - ptx - bsz));
+    const int   ymin = max(1,          (int)floorf(y - pty - bsz));
+    const int   xmax = min(width - 2,  (int)floorf(x + ptx + bsz));
+    const int   ymax = min(height - 2, (int)floorf(y + pty + bsz));
+
+    __shared__ float dpt[4][128];
+    for( int i=threadIdx.x; i<128; i+=blockDim.x )
+    {
+        dpt[0][i] = 0.0f;
+        dpt[1][i] = 0.0f;
+        dpt[2][i] = 0.0f;
+        dpt[3][i] = 0.0f;
+    }
+    __syncthreads();
+
+    // we have 32 threads in a warp, how to use them?
+    const int tx = ( ( threadIdx.x >> 0 ) & 0x1 ); // 0 - 1
+    const int ty = ( ( threadIdx.x >> 1 ) & 0x1 ); // 0 - 1
+    const int tt = ( ( threadIdx.x >> 2 ) & 0x1 ); // 0 - 1
+    const int loop = threadIdx.x >> 3;             // 0 - 3
+
+    for( int pix_y = ymin+loop; popsift::any(pix_y <= ymax); pix_y += 4 )
+    {
+        for( int pix_x = xmin; pix_x <= xmax; pix_x++ )
+        {
+            if( pix_y <= ymax )
+            {
+                // d : distance from keypoint
+                const float2 d = make_float2( pix_x - x, pix_y - y );
+
+                // n : normalized distance from keypoint
+                const float2 n = make_float2( ::fmaf( crsbp, d.x,  srsbp * d.y ),
+                                              ::fmaf( crsbp, d.y, -srsbp * d.x ) ); 
+
+                float mod;
+                float th;
+
+                get_gradiant( mod, th, pix_x, pix_y, layer_tex, level );
+
+                mod /= 2; // Our mod is double that of vlfeat. Huh.
+
+                const float  ww = __expf( -scalbnf(n.x*n.x + n.y*n.y, -3));
+
+                th -= ang;
+                while( th > M_PI2 ) th -= M_PI2;
+                while( th < 0.0f  ) th += M_PI2;
+
+                const float nt = 8.0f * th / M_PI2;
+
+                // neighbouring tile on the lower side: -2, -1, 0 or 1
+                // (must use floorf because casting rounds towards zero
+                const int3 t0 = make_int3( (int)floorf(n.x - 0.5f),
+                                        (int)floorf(n.y - 0.5f),
+                                        (int)nt );
+                float wgt_x = - ( n.x - ( t0.x + 0.5f ) );
+                float wgt_y = - ( n.y - ( t0.y + 0.5f ) );
+                float wgt_t = - ( nt  - t0.z );
+
+                if( ( t0.y + ty >= -2 ) &&
+                    ( t0.y + ty <   2 ) &&
+                    ( t0.x + tx >= -2 ) &&
+                    ( t0.x + tx <   2 ) )
+                {
+                    wgt_x = ( tx == 0 ) ? 1.0f + wgt_x : wgt_x;
+                    wgt_y = ( ty == 0 ) ? 1.0f + wgt_y : wgt_y;
+                    wgt_t = ( tt == 0 ) ? 1.0f + wgt_t : wgt_t;
+
+                    wgt_x = fabsf( wgt_x );
+                    wgt_y = fabsf( wgt_y );
+                    wgt_t = fabsf( wgt_t );
+
+                    const float val = ww
+                                    * mod
+                                    * wgt_x
+                                    * wgt_y
+                                    * wgt_t;
+
+                    const int offset =  80
+                                    + ( t0.y + ty ) * 32
+                                    + ( t0.x + tx ) * 8
+                                    + ( t0.z + tt ) % 8;
+
+                    dpt[loop][offset] += val;
+                }
+            }
+            __syncthreads();
+        }
+    }
+
+    for( int i=threadIdx.x; i<128; i+=blockDim.x )
+    {
+        float f = dpt[0][i] + dpt[1][i] + dpt[2][i] + dpt[3][i];
+        features[i] = f;
+    }
+}
+
+__global__ void ext_desc_vlfeat(int octave, cudaTextureObject_t layer_tex, int w, int h)
+{           
+    const int   o_offset =  dct.ori_ps[octave] + blockIdx.x;
+    Descriptor* desc     = &dbuf.desc           [o_offset];
+    const int   ext_idx  =  dobuf.feat_to_ext_map[o_offset];
+    Extremum*   ext      =  dobuf.extrema + ext_idx;
+
+    const int   ext_base =  ext->idx_ori;
+    const int   ori_num  =  o_offset - ext_base;
+    const float ang      =  ext->orientation[ori_num];
+
+    ext_desc_vlfeat_sub( ang,
+                         ext,
+                         desc->features,
+                         layer_tex,
+                         w,
+                         h );
+}
+
+namespace popsift
+{
+
+bool start_ext_desc_vlfeat( const int octave, Octave& oct_obj )
+{
+    dim3 block;
+    dim3 grid;
+    grid.x = hct.ori_ct[octave];
+    grid.y = 1;
+    grid.z = 1;
+
+    if( grid.x == 0 ) return false;
+
+    block.x = 32;
+    block.y = 1;
+    block.z = 1;
+
+    size_t shared_size = 4 * 128 * sizeof(float);
+
+    ext_desc_vlfeat
+        <<<grid,block,shared_size,oct_obj.getStream()>>>
+        ( octave,
+          oct_obj.getDataTexPoint( ),
+          oct_obj.getWidth(),
+          oct_obj.getHeight() );
+
+    POP_SYNC_CHK;
+
+    return true;
+}
+
+}; // namespace popsift
+

--- a/src/popsift/s_desc_vlfeat.h
+++ b/src/popsift/s_desc_vlfeat.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016-2017, Simula Research Laboratory
+ *           2018-2020, University of Oslo
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#pragma once
+#include "sift_octave.h"
+
+namespace popsift
+{
+
+bool start_ext_desc_vlfeat( const int octave, Octave& oct_obj );
+
+}; // namespace popsift
+

--- a/src/popsift/sift_conf.cu
+++ b/src/popsift/sift_conf.cu
@@ -80,6 +80,8 @@ void Config::setDescMode( const std::string& text )
         setDescMode( Config::IGrid );
     else if( text == "notile" )
         setDescMode( Config::NoTile );
+    else if( text == "vlfeat" )
+        setDescMode( Config::VLFeat_Desc );
     else
         POP_FATAL( "specified descriptor extraction mode must be one of loop, grid or igrid" );
 }

--- a/src/popsift/sift_conf.h
+++ b/src/popsift/sift_conf.h
@@ -95,6 +95,10 @@ struct Config
         IGrid,
         /// loop-compatible; variant of IGrid, no duplicate gradient fetching
         NoTile,
+        /** extraction code according to VLFeat, similar to loop, weight goes into
+         *  up to 8 histogram bins
+         */
+        VLFeat_Desc
     };
 
     /**

--- a/src/popsift/sift_conf.h
+++ b/src/popsift/sift_conf.h
@@ -74,6 +74,7 @@ struct Config
      */
     enum ScalingMode
     {
+        /// Experimental, non-working mode - scale direct from input
         ScaleDirect,
         /// Indirect - only working method
         ScaleDefault
@@ -84,16 +85,16 @@ struct Config
      */
     enum DescMode
     {
-        /// scan horizontal, extract valid points
+        /// scan horizontal, extract valid points - weight goes into 2 histogram bins
         Loop,
-        /// scan horizontal, extract valid points, interpolate with tex engine
+        /// loop-compatible; scan horizontal, extract valid points, interpolate with tex engine
         ILoop,
-        /// scan in rotated mode, round pixel address
+        /// loop-compatible; scan in rotated mode, round pixel address
         Grid,
-        /// scan in rotated mode, interpolate with tex engine
+        /// loop-compatible; scan in rotated mode, interpolate with tex engine
         IGrid,
-        /// variant of IGrid, no duplicate gradient fetching
-        NoTile
+        /// loop-compatible; variant of IGrid, no duplicate gradient fetching
+        NoTile,
     };
 
     /**
@@ -104,7 +105,9 @@ struct Config
         /// The L1-inspired norm, gives better matching results ("RootSift")
         RootSift,
         /// The L2-inspired norm, all descriptors on a hypersphere ("classic")
-        Classic
+        Classic,
+        /// The current default value
+        NormDefault = RootSift
     };
 
     /**
@@ -160,6 +163,12 @@ struct Config
      * @see LogMode
      */
     void setLogMode( LogMode mode = All );
+
+    /**
+     * @brief Set the scaling mode.
+     * @param mode The scaling mode
+     * @see ScalingMode
+     */
     void setScalingMode( ScalingMode mode = ScaleDefault );
 
     /**
@@ -182,16 +191,36 @@ struct Config
     */
     void setDescMode( DescMode mode = Loop );
 
+    /**
+     * @brief Helper functions for the main program's usage string.
+     */
+    static const char* getDescModeUsage( );
+
 //    void setGaussGroup( int groupsize );
 //    int  getGaussGroup( ) const;
 
-    void setDownsampling( float v );
+    void  setDownsampling( float v );
+    float getDownsampling( ) const;
+
     void setOctaves( int v );
+    int  getOctaves( ) const;
+
     void setLevels( int v );
-    void setSigma( float v );
-    void setEdgeLimit( float v );
-    void setThreshold( float v );
-    void setInitialBlur( float blur );
+    int  getLevels( ) const;
+
+    void  setSigma( float v );
+    float getSigma( ) const;
+
+    void  setEdgeLimit( float v );
+    float getEdgeLimit( ) const;
+
+    void  setThreshold( float v );
+    float getThreshold( ) const;
+
+    void  setInitialBlur( float blur );
+    bool  hasInitialBlur( ) const;
+    float getInitialBlur( ) const;
+
 //    void setMaxExtreme( int m );
     void setPrintGaussTables( );
 //    void setDPOrientation( bool on );
@@ -199,9 +228,6 @@ struct Config
     void setFilterGridSize( int sz );
     void setFilterSorting( const std::string& direction );
     void setFilterSorting( GridFilterMode m );
-
-    bool  hasInitialBlur( ) const;
-    float getInitialBlur( ) const;
 
     /// computes the actual peak threshold depending on the threshold
     /// parameter and the non-augmented number of levels
@@ -321,7 +347,7 @@ struct Config
 
     /**
      * @brief Get the scaling mode.
-     * @return the descriptor extraction mode.
+     * @return the extraction mode.
      * @see ScalingMode
      */
     inline ScalingMode getScalingMode() const { return _scaling_mode; }

--- a/src/popsift/sift_desc.cu
+++ b/src/popsift/sift_desc.cu
@@ -13,6 +13,7 @@
 #include "s_desc_loop.h"
 #include "s_desc_normalize.h"
 #include "s_desc_notile.h"
+#include "s_desc_vlfeat.h"
 #include "s_gradiant.h"
 #include "sift_config.h"
 #include "sift_constants.h"
@@ -77,6 +78,8 @@ void Pyramid::descriptors( const Config& conf )
                 start_ext_desc_igrid( octave, oct_obj );
             } else if( conf.getDescMode() == Config::NoTile ) {
                 start_ext_desc_notile( octave, oct_obj );
+            } else if( conf.getDescMode() == Config::VLFeat_Desc ) {
+                start_ext_desc_vlfeat( octave, oct_obj );
             } else {
                 POP_FATAL( "not yet" );
             }

--- a/src/popsift/sift_desc.cu
+++ b/src/popsift/sift_desc.cu
@@ -88,15 +88,16 @@ void Pyramid::descriptors( const Config& conf )
     if( hct.ori_total == 0 )
     {
         cerr << "Warning: no descriptors extracted" << endl;
-	return;
+        return;
     }
 
     dim3 block;
-    dim3 grid;
-    grid.x  = grid_divide( hct.ori_total, 32 );
     block.x = 32;
     block.y = 32;
     block.z = 1;
+
+    dim3 grid;
+    grid.x  = grid_divide( hct.ori_total, block.y );
 
     if( conf.getUseRootSift() ) {
         normalize_histogram<NormalizeRootSift> <<<grid,block,0,_download_stream>>> ( );

--- a/testScripts/CMakeLists.txt
+++ b/testScripts/CMakeLists.txt
@@ -26,3 +26,5 @@ add_custom_target(
  	DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/testOxfordDataset.sh
 	DEPENDS popsift-demo
 )
+
+add_subdirectory(CompareDescriptors)

--- a/testScripts/CompareDescriptors/CMakeLists.txt
+++ b/testScripts/CompareDescriptors/CMakeLists.txt
@@ -1,0 +1,46 @@
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+
+find_program(AWK awk mawk gawk)
+find_program(SORT sort)
+find_program(GNUPLOT gnuplot)
+find_program(CONVERT convert)
+find_program(VLFEAT sift PATH_SUFFIXES glnxa64 bin/glnxa64)
+
+if(AWK MATCHES ".+-NOTFOUND")
+    message(WARNING  "WARNING: awk (and mawk and gawk) could not be found (${AWK}).")
+else()
+    message(STATUS  "awk found (${AWK}).")
+endif()
+
+if(SORT MATCHES ".+-NOTFOUND")
+    message(WARNING  "WARNING: sort could not be found (${SORT}).")
+else()
+    message(STATUS  "sort found (${SORT}).")
+endif()
+
+if(GNUPLOT MATCHES ".+-NOTFOUND")
+    message(WARNING  "WARNING: gnupot could not be found (${GNUPLOT}).")
+else()
+    message(STATUS  "gnuplot found (${GNUPLOT}).")
+endif()
+
+if(CONVERT MATCHES ".+-NOTFOUND")
+    message(WARNING  "WARNING: ImageMagick's convert could not be found (${CONVERT}).")
+else()
+    message(STATUS  "convert found (${CONVERT}).")
+endif()
+
+if(VLFEAT MATCHES ".+-NOTFOUND")
+    message(WARNING  "WARNING: vlfeat could not be found (${VLFEAT}).")
+else()
+    message(STATUS  "vlfeat found (${VLFEAT}).")
+endif()
+
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/compareWithVLFeat.sh.in
+                ${CMAKE_CURRENT_BINARY_DIR}/compareWithVLFeat.sh
+		@ONLY)
+
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/Compare.mk.in
+                Compare.mk
+		@ONLY)
+

--- a/testScripts/CompareDescriptors/Compare.mk.in
+++ b/testScripts/CompareDescriptors/Compare.mk.in
@@ -1,0 +1,14 @@
+all: test
+
+test: @CMAKE_RUNTIME_OUTPUT_DIRECTORY@/popsift-compareSiftFiles
+	sh ./compareWithVLFeat.sh
+
+clean:
+	rm -f sort*.txt
+	rm -f sort*.png
+	rm -f *.sift
+	rm -f descdist*.txt
+	rm -f descdist*.png
+	rm -f tmp/*.sift tmp/UML*.txt tmp/sort*.txt tmp/coord*.txt tmp/sum*.txt
+	rm -f tmp/descdist*.txt
+

--- a/testScripts/CompareDescriptors/awk/compute.awk
+++ b/testScripts/CompareDescriptors/awk/compute.awk
@@ -1,0 +1,18 @@
+{
+	printf("%f %f -- ", $1, $2);
+	total = 0
+	for(i=5; i<=NF; i++) { total = total + $i; }
+	printf("%d -- ", total);
+	i = 5;
+	for(r=0; r<16; r++)
+	{
+		total = 0
+		for(i=0; i<8; i++)
+		{
+			idx = 5 + r*8 + i
+			total = total + $idx;
+		}
+		printf("%d ", total/8);
+	}
+	printf("\n");
+}

--- a/testScripts/CompareDescriptors/awk/desc-to-heat.awk
+++ b/testScripts/CompareDescriptors/awk/desc-to-heat.awk
@@ -1,0 +1,23 @@
+BEGIN {
+	x = -1.5;
+	y = -1.5;
+}
+
+{
+	if( NF == 10 )
+	{
+		printf("%.1f %.1f %f\n", x, y, $COL);
+		x = x + 1;
+		if( x > 2 )
+		{
+			printf("\n");
+			x = -1.5;
+			y = y + 1;
+		}
+	}
+}
+
+END {
+	printf("\n");
+}
+

--- a/testScripts/CompareDescriptors/compareWithVLFeat.sh.in
+++ b/testScripts/CompareDescriptors/compareWithVLFeat.sh.in
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+CMD_VLF=@VLFEAT@
+CMD_POP=@CMAKE_RUNTIME_OUTPUT_DIRECTORY@/popsift-demo
+CMD_AWK=@AWK@
+CMD_SORT=@SORT@
+CMD_GP=@GNUPLOT@
+CMD_CONVERT=@CONVERT@
+CMD_COMPARE=@CMAKE_RUNTIME_OUTPUT_DIRECTORY@/popsift-compareSiftFiles
+DIR_AWK=@CMAKE_CURRENT_SOURCE_DIR@/awk
+DIR_TEST=@PopSift_TESTFILE_PATH@
+
+run_vlfeat() {
+    file="$1"
+
+    echo ${CMD_VLF} -v ${file}.pgm
+    ${CMD_VLF} -v ${file}.pgm
+    ${CMD_SORT} -n ${file}.sift > tmp/${file}-vlfeat.sift
+    rm ${file}.sift
+    ${CMD_AWK} -e '{printf("%f %f %f %f\n",$1,$2,$3,$4);}' < tmp/${file}-vlfeat.sift > tmp/coord-${file}-vlfeat.txt
+    ${CMD_AWK} -f ${DIR_AWK}/compute.awk tmp/${file}-vlfeat.sift > tmp/sum-${file}-vlfeat.txt
+    echo "LEAVE VLFEAT"
+}
+
+run_popsift() {
+    file="$1"
+    par="$2"
+
+    # VLFeat multiplies the descriptors with 512 before converting to uchar,
+    # so we use 9 for a 2**9 multiplier as well.
+    PAR0="--pgmread-loading --norm-mode=classic --norm-multi 9 --write-as-uchar --write-with-ori --initial-blur 0.5 --sigma 1.6 --threshold 0 --edge-threshold 10.0"
+
+    echo ${CMD_POP} ${PAR0} ${par} -i ${file}.pgm
+    ${CMD_POP} ${PAR0} ${par} -i ${file}.pgm
+    ${CMD_SORT} -n output-features.txt > tmp/${file}-popsift.sift
+    rm output-features.txt
+    ${CMD_AWK} -e '{printf("%f %f %f %f\n",$1,$2,$3,$4);}' < tmp/${file}-popsift.sift > tmp/coord-${file}-popsift.txt
+    ${CMD_AWK} -f ${DIR_AWK}/compute.awk tmp/${file}-popsift.sift > tmp/sum-${file}-popsift.txt
+    echo "LEAVE POPSIFT"
+}
+
+mkdir -p tmp
+
+# for TESTNAME in default new twobins vlfeatdesc vlfeat
+for TESTNAME in new vlfeatdesc
+do
+
+    rm -f hash.sift*
+    rm -f level1.sift*
+    rm -f coord-*
+    rm -f sum-*
+
+    # FILES="hash level1 boat"
+    # FILES="level1"
+    # FILES="hash"
+    FILES="boat"
+    # FILES="boat1"
+
+    for file in ${FILES} ; do
+	if [ ! -f ${file}.pgm ]
+	then
+            ${CMD_CONVERT} ${DIR_TEST}/$file/img1.ppm ${file}.pgm
+	    if [ $? -ne 0 ]
+	    then
+	    	echo "${CMD_CONVERT} failed, test image not converted"
+		exit -1
+	    fi
+	fi
+
+        if [ "$TESTNAME" = "default" ]; then
+	    echo "Test is default"
+	    PAR1=" "
+        elif [ "$TESTNAME" = "new" ]; then
+	    echo "Test is new: loopdescriptor and BestBin"
+	    PAR1="--desc-mode=loop"
+        elif [ "$TESTNAME" = "vlfeatdesc" ]; then
+	    echo "Test is vlfeatdesc: vlfeat descriptor and BestBin"
+	    PAR1="--desc-mode=vlfeat"
+        else
+	    echo "Test is undefined, $TESTNAME"
+	    exit
+        fi
+
+    	run_vlfeat ${file}
+
+    	run_popsift ${file} ${PAR1}
+
+	echo "Perform brute force matching"
+	echo ${CMD_COMPARE} ${file}-popsift.sift ${file}-vlfeat.sift
+	${CMD_COMPARE} -o tmp/UML-${file}.txt \
+	               -d tmp/descdist-${file}-${TESTNAME}.txt \
+	               tmp/${file}-popsift.sift \
+	               tmp/${file}-vlfeat.sift
+
+	echo "Sorting"
+	${CMD_SORT} -k3  -g tmp/UML-${file}.txt > tmp/sort-${file}-by-1st-match.txt
+	${CMD_SORT} -k6  -g tmp/UML-${file}.txt > tmp/sort-${file}-by-pixdist.txt
+	${CMD_SORT} -k8  -g tmp/UML-${file}.txt > tmp/sort-${file}-by-angle.txt
+	${CMD_SORT} -k10 -g tmp/UML-${file}.txt > tmp/sort-${file}-by-2nd-match.txt
+
+	echo "Converting descriptor distance stats"
+	awk -vCOL=3  -f ${DIR_AWK}/desc-to-heat.awk tmp/descdist-${file}-${TESTNAME}.txt >  descdist-${file}-${TESTNAME}.txt
+	awk -vCOL=4  -f ${DIR_AWK}/desc-to-heat.awk tmp/descdist-${file}-${TESTNAME}.txt >> descdist-${file}-${TESTNAME}.txt
+	awk -vCOL=5  -f ${DIR_AWK}/desc-to-heat.awk tmp/descdist-${file}-${TESTNAME}.txt >> descdist-${file}-${TESTNAME}.txt
+	awk -vCOL=6  -f ${DIR_AWK}/desc-to-heat.awk tmp/descdist-${file}-${TESTNAME}.txt >> descdist-${file}-${TESTNAME}.txt
+	awk -vCOL=7  -f ${DIR_AWK}/desc-to-heat.awk tmp/descdist-${file}-${TESTNAME}.txt >> descdist-${file}-${TESTNAME}.txt
+	awk -vCOL=8  -f ${DIR_AWK}/desc-to-heat.awk tmp/descdist-${file}-${TESTNAME}.txt >> descdist-${file}-${TESTNAME}.txt
+	awk -vCOL=9  -f ${DIR_AWK}/desc-to-heat.awk tmp/descdist-${file}-${TESTNAME}.txt >> descdist-${file}-${TESTNAME}.txt
+	awk -vCOL=10 -f ${DIR_AWK}/desc-to-heat.awk tmp/descdist-${file}-${TESTNAME}.txt >> descdist-${file}-${TESTNAME}.txt
+
+	echo "Calling gnuplot (pixdist)"
+	echo "set title \"L2 distance between pixels, PopSift ${TESTNAME} vs VLFeat" > cmd.gp
+	echo "set xlabel \"Keypoint index sorted by closest best match\"" >> cmd.gp
+	echo "set logscale y" >> cmd.gp
+	echo "set terminal png" >> cmd.gp
+	echo "set output \"sort-${file}-by-pixdist-${TESTNAME}.png\"" >> cmd.gp
+	echo "plot \"tmp/sort-${file}-by-pixdist.txt\" using (\$6+0.00001) notitle" >> cmd.gp
+	${CMD_GP} cmd.gp
+
+	echo "Calling gnuplot (1st dist)"
+	echo "set title \"L2 distance between descriptors, PopSift ${TESTNAME} vs VLFeat" > cmd.gp
+	echo "set xlabel \"Keypoint index sorted by closest best match\"" >> cmd.gp
+	echo "set terminal png" >> cmd.gp
+	echo "set output \"/dev/null\"" >> cmd.gp
+	echo "plot   \"tmp/sort-${file}-by-1st-match.txt\" using 3 title \"best distance\"" >> cmd.gp
+	echo "replot \"tmp/sort-${file}-by-1st-match.txt\" using 10 title \"2nd best distance\"" >> cmd.gp
+	echo "set output \"sort-${file}-by-1st-match-${TESTNAME}.png\"" >> cmd.gp
+	echo "replot" >> cmd.gp
+	${CMD_GP} cmd.gp
+
+	echo "Calling gnuplot for angular diff (1st dist)"
+	echo "set title \"Distance in degree between orientations, PopSift ${TESTNAME} vs VLFeat" > cmd.gp
+	echo "set ylabel \"Difference (degree)\"" >> cmd.gp
+	echo "set xlabel \"Keypoint index sorted by orientation difference\"" >> cmd.gp
+	echo "set grid" >> cmd.gp
+	echo "set logscale y" >> cmd.gp
+	echo "set yrange [0.001:*]" >> cmd.gp
+	echo "set style data lines" >> cmd.gp
+	echo "set terminal png" >> cmd.gp
+	echo "set output \"sort-${file}-by-angle-${TESTNAME}.png\"" >> cmd.gp
+	echo "plot \"tmp/sort-${file}-by-angle.txt\" using 8 notitle" >> cmd.gp
+	${CMD_GP} cmd.gp
+
+	echo "Calling gnuplot (2nd dist)"
+	echo "set title \"L2 distance between descriptors, PopSift ${TESTNAME} vs VLFeat" > cmd.gp
+	echo "set xlabel \"Keypoint index sorted by 2nd best match\"" >> cmd.gp
+	echo "set terminal png" >> cmd.gp
+	echo "set output \"/dev/null\"" >> cmd.gp
+	echo "plot   \"tmp/sort-${file}-by-2nd-match.txt\" using 3 title \"best distance\"" >> cmd.gp
+	echo "replot \"tmp/sort-${file}-by-2nd-match.txt\" using 10 title \"2nd best distance\"" >> cmd.gp
+	echo "set output \"sort-${file}-by-2nd-match-${TESTNAME}.png\"" >> cmd.gp
+	echo "replot" >> cmd.gp
+	${CMD_GP} cmd.gp
+
+	echo "Calling gnuplot (descriptor summary)"
+	echo "set view 80, 20, 1, 1.48" > cmd.gp
+	echo "set xrange [ -1.5 : 1.5 ]" >> cmd.gp
+	echo "set yrange [ -1.5 : 1.5 ]" >> cmd.gp
+	echo "set zrange [ -5 : 5 ]" >> cmd.gp
+	echo "set xtics -1.5,3 offset 0,-0.5" >> cmd.gp
+	echo "set ytics 1.5,3 offset 0.5" >> cmd.gp
+	echo "set ztics -3,3" >> cmd.gp
+	echo "set ticslevel 0" >> cmd.gp
+	echo "set format cb '%4.1f'" >> cmd.gp
+	echo "unset colorbox" >> cmd.gp
+	echo "set pm3d implicit at s" >> cmd.gp
+	echo "set terminal png size 1080, 250" >> cmd.gp
+	echo "set output \"descdist-${file}-${TESTNAME}.png\"" >> cmd.gp
+	echo "set multiplot layout 1,8 title '8 bins in each of 16 sections'" >> cmd.gp
+	echo "set title 'bin 0 '" >> cmd.gp
+	echo "splot \"descdist-${file}-${TESTNAME}.txt\" index 0 using 1:2:3:3 with pm3d notitle" >> cmd.gp
+	echo "set title 'bin 1 '" >> cmd.gp
+	echo "splot \"descdist-${file}-${TESTNAME}.txt\" index 1 using 1:2:3:3 with pm3d notitle" >> cmd.gp
+	echo "set title 'bin 2 '" >> cmd.gp
+	echo "splot \"descdist-${file}-${TESTNAME}.txt\" index 2 using 1:2:3:3 with pm3d notitle" >> cmd.gp
+	echo "set title 'bin 3 '" >> cmd.gp
+	echo "splot \"descdist-${file}-${TESTNAME}.txt\" index 3 using 1:2:3:3 with pm3d notitle" >> cmd.gp
+	echo "set title 'bin 4 '" >> cmd.gp
+	echo "splot \"descdist-${file}-${TESTNAME}.txt\" index 4 using 1:2:3:3 with pm3d notitle" >> cmd.gp
+	echo "set title 'bin 5 '" >> cmd.gp
+	echo "splot \"descdist-${file}-${TESTNAME}.txt\" index 5 using 1:2:3:3 with pm3d notitle" >> cmd.gp
+	echo "set title 'bin 6 '" >> cmd.gp
+	echo "splot \"descdist-${file}-${TESTNAME}.txt\" index 6 using 1:2:3:3 with pm3d notitle" >> cmd.gp
+	echo "set title 'bin 7 '" >> cmd.gp
+	echo "splot \"descdist-${file}-${TESTNAME}.txt\" index 7 using 1:2:3:3 with pm3d notitle" >> cmd.gp
+	${CMD_GP} cmd.gp
+
+	rm -f cmd.gp
+    done
+done
+


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

The test script runs VLFeat and PopSift on one or more images and creates the descriptors with orientations.
compareSiftFiles.cpp performs a brute force comparison of the output files and outputs sorted files and some distance computations.
These are then transformed bash and awk and rendered visually with gnuplot.

## Features list

<!--
- [ ] Feature one. Fix #XXX
- [ ] Improve something else
- [ ] Connect to #3 (to declare link to issues without closing it when the PR is merged).
- [X] Add "X" when it is done.
-->

New binary that compares two files containing SIFT descriptors. VLFeat and Matlab syntax supported.
Scripts that compare VLFeat-compatible PopSift behaviour with original VLFeat behaviour. Requires new command line options of PR  #114 before they can work.

## Implementation remarks

The popsift-compareSiftFiles is fairly stand-alone. It uses boost, but not CUDA.

The scripts are based on bash, they depend on a lot of Unix command line tools, ImageMagick and Gnuplot. These should be seen as examples.

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->
