### PR TITLE
Add missing thrust include

### DIFF
--- a/src/popsift/s_filtergrid.cu
+++ b/src/popsift/s_filtergrid.cu
@@ -21,6 +21,7 @@
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
+#include <thrust/host_vector.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>


### PR DESCRIPTION
Adding this include was necessary to compile popsift in my environment (with CUDA release 11.4, V11.4.48).