### PR TITLE
[ci] added github actions for CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,7 @@ jobs:
 
     env:
       DEPS_INSTALL_DIR: /opt/
-      BUILD_TYPE: Release
+      BUILD_TYPE: ${{ matrix.build_tpe }}
       CTEST_OUTPUT_ON_FAILURE: 1
     steps:
       - uses: actions/checkout@v2
@@ -60,5 +60,6 @@ jobs:
         run: |
           cmake ../src/application \
            -DBUILD_SHARED_LIBS:BOOL=ON \
+           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
            -DCMAKE_PREFIX_PATH:PATH="$PWD/../../popsift_install;${DEPS_INSTALL_DIR}"
           make -j$(nproc)

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,64 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+    # Skip jobs when only documentation files are changed
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
+      - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
+      - 'docs/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container: ["alicevision/popsift-deps:cuda10.2-ubuntu18.04", "alicevision/popsift-deps:cuda11.8.0-ubuntu20.04", "alicevision/popsift-deps:cuda12.1.0-ubuntu22.04"]
+        build_tpe: ["Release", "Debug"]
+
+    container:
+      image: ${{ matrix.container }}
+
+    env:
+      DEPS_INSTALL_DIR: /opt/
+      BUILD_TYPE: Release
+      CTEST_OUTPUT_ON_FAILURE: 1
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Prepare File Tree
+        run: |
+          mkdir ./build
+          mkdir ./build_as_3rdparty
+          mkdir ../popsift_install
+
+      - name: Configure CMake
+        working-directory: ./build
+        run: |
+          cmake .. \
+           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+           -DBUILD_SHARED_LIBS:BOOL=ON \
+           -DCMAKE_PREFIX_PATH="${DEPS_INSTALL_DIR}" \
+           -DPopSift_BUILD_DOCS:BOOL=OFF \
+           -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../../popsift_install
+
+      - name: Build
+        working-directory: ./build
+        run: |
+          make -j$(nproc) install
+
+      - name: Build As Third Party
+        working-directory: ./build_as_3rdparty
+        run: |
+          cmake ../src/application \
+           -DBUILD_SHARED_LIBS:BOOL=ON \
+           -DCMAKE_PREFIX_PATH:PATH="$PWD/../../popsift_install;${DEPS_INSTALL_DIR}"
+          make -j$(nproc)

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,6 +23,10 @@ jobs:
       matrix:
         container: ["alicevision/popsift-deps:cuda10.2-ubuntu18.04", "alicevision/popsift-deps:cuda11.8.0-ubuntu20.04", "alicevision/popsift-deps:cuda12.1.0-ubuntu22.04"]
         build_tpe: ["Release", "Debug"]
+        exclude:
+        # excludes debug on this one as it has a segmentation fault during the compilation (!)
+        - container: "alicevision/popsift-deps:cuda12.1.0-ubuntu22.04"
+          build_tpe: "Debug"
 
     container:
       image: ${{ matrix.container }}

--- a/Dockerfile_deps
+++ b/Dockerfile_deps
@@ -7,7 +7,7 @@ LABEL maintainer="AliceVision Team alicevision@googlegroups.com"
 # see https://hub.docker.com/r/nvidia/cuda/
 #
 # For example, to create a ubuntu 16.04 with cuda 8.0 for development, use
-# docker build --build-arg CUDA_TAG=8.0 --tag alicevision/popsift-deps:cuda${CUDA_TAG}-ubuntu${OS_TAG} .
+# docker build --build-arg CUDA_TAG=8.0 --tag alicevision/popsift-deps:cuda${CUDA_TAG}-ubuntu${OS_TAG} -f Dockerfile_deps .
 #
 # then execute with nvidia docker (https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0))
 # docker run -it --runtime=nvidia popsift_deps
@@ -32,12 +32,12 @@ RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommend
         libboost-thread-dev \
  && rm -rf /var/lib/apt/lists/*
  
- # Manually install cmake
+# Manually install cmake
 WORKDIR /tmp/cmake
-ENV CMAKE_VERSION=3.17
+ENV CMAKE_VERSION=3.24
 ENV CMAKE_VERSION_FULL=${CMAKE_VERSION}.2
-RUN wget https://cmake.org/files/v3.17/cmake-${CMAKE_VERSION_FULL}.tar.gz && \
-    tar zxvf cmake-${CMAKE_VERSION_FULL}.tar.gz && \
+RUN wget https://cmake.org/files/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION_FULL}.tar.gz && \
+    tar zxf cmake-${CMAKE_VERSION_FULL}.tar.gz && \
     cd cmake-${CMAKE_VERSION_FULL} && \
     ./bootstrap --prefix=/usr/local  -- -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_USE_OPENSSL:BOOL=ON && \
     make -j$(nproc) install && \

--- a/README.md
+++ b/README.md
@@ -101,8 +101,11 @@ In particular, users can choose to generate results very similar to VLFeat or re
 We acknowledge that there is at least one SIFT implementation that is vastly faster, but it makes considerable sacrifices in terms of accuracy and compatibility.
 
 ## Continuous integration:
+
 - ![Continuous Integration](https://github.com/alicevision/popsift/workflows/Continuous%20Integration/badge.svg?branch=master) master branch on Linux.
+
 - ![Continuous Integration](https://github.com/alicevision/popsift/workflows/Continuous%20Integration/badge.svg?branch=develop) develop branch on Linux.
+
 - [![Build status](https://ci.appveyor.com/api/projects/status/rsm5269hs288c2ji/branch/develop?svg=true)](https://ci.appveyor.com/project/AliceVision/popsift/branch/develop)
   develop branch on Windows.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # PopSift
 
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3728/badge)](https://bestpractices.coreinfrastructure.org/projects/3728)  [!
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3728/badge)](https://bestpractices.coreinfrastructure.org/projects/3728) 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/64f9192b53df46b483e7cf5be7e2dddd)](https://app.codacy.com/gh/alicevision/popsift/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 PopSift is an open-source implementation of the SIFT algorithm in CUDA.
@@ -101,10 +101,10 @@ In particular, users can choose to generate results very similar to VLFeat or re
 We acknowledge that there is at least one SIFT implementation that is vastly faster, but it makes considerable sacrifices in terms of accuracy and compatibility.
 
 ## Continuous integration:
-- [![Build Status](https://travis-ci.org/alicevision/popsift.svg?branch=master)](https://travis-ci.org/alicevision/popsift) master branch.
-- [![Build Status](https://travis-ci.org/alicevision/popsift.svg?branch=develop)](https://travis-ci.org/alicevision/popsift) develop branch.
+- ![Continuous Integration](https://github.com/alicevision/popsift/workflows/Continuous%20Integration/badge.svg?branch=master) master branch on Linux.
+- ![Continuous Integration](https://github.com/alicevision/popsift/workflows/Continuous%20Integration/badge.svg?branch=develop) develop branch on Linux.
 - [![Build status](https://ci.appveyor.com/api/projects/status/rsm5269hs288c2ji/branch/develop?svg=true)](https://ci.appveyor.com/project/AliceVision/popsift/branch/develop)
-  develop branch.
+  develop branch on Windows.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 
 # PopSift
 
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3728/badge)](https://bestpractices.coreinfrastructure.org/projects/3728)  [![Codacy Badge](https://api.codacy.com/project/badge/Grade/8b0f7a68bc0d4df2ac89c6e732917caa)](https://app.codacy.com/manual/alicevision/popsift?utm_source=github.com&utm_medium=referral&utm_content=alicevision/popsift&utm_campaign=Badge_Grade_Settings)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3728/badge)](https://bestpractices.coreinfrastructure.org/projects/3728)  [!
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/64f9192b53df46b483e7cf5be7e2dddd)](https://app.codacy.com/gh/alicevision/popsift/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 PopSift is an open-source implementation of the SIFT algorithm in CUDA.
 PopSift tries to stick as closely as possible to David Lowe's famous paper [1], while extracting features from an image in real-time at least on an NVidia GTX 980 Ti GPU.

--- a/README.md
+++ b/README.md
@@ -102,12 +102,11 @@ We acknowledge that there is at least one SIFT implementation that is vastly fas
 
 ## Continuous integration:
 
-- ![Continuous Integration](https://github.com/alicevision/popsift/workflows/Continuous%20Integration/badge.svg?branch=master) master branch on Linux.
+* ![Continuous Integration](https://github.com/alicevision/popsift/workflows/Continuous%20Integration/badge.svg?branch=master) master branch on Linux.
 
-- ![Continuous Integration](https://github.com/alicevision/popsift/workflows/Continuous%20Integration/badge.svg?branch=develop) develop branch on Linux.
+* ![Continuous Integration](https://github.com/alicevision/popsift/workflows/Continuous%20Integration/badge.svg?branch=develop) develop branch on Linux.
 
-- [![Build status](https://ci.appveyor.com/api/projects/status/rsm5269hs288c2ji/branch/develop?svg=true)](https://ci.appveyor.com/project/AliceVision/popsift/branch/develop)
-  develop branch on Windows.
+* [![Build status](https://ci.appveyor.com/api/projects/status/rsm5269hs288c2ji/branch/develop?svg=true)](https://ci.appveyor.com/project/AliceVision/popsift/branch/develop) develop branch on Windows.
 
 ## License
 


### PR DESCRIPTION
Add the CI using GitHub actions. It builds on 3 different containers with different versions of cuda and of ubuntu.

* cuda 10.2 on ubuntu 18.04  with gcc 7.4
* cuda 11.8.0 on ubuntu 20.04 with gcc 9.4
* cuda 12.1.0 on ubuntu 22.04  with gcc 11.3

Note that for cuda 12 there is currently a segfault error while compiling in Debug, so for the moment the debug is excluded in this version.

The `Dockerfile_deps` is also updated to use a more recent version of cmake
