### PR TITLE
fix illegal access when there are more orientations than allocated

### DIFF
--- a/src/popsift/s_desc_grid.cu
+++ b/src/popsift/s_desc_grid.cu
@@ -123,9 +123,15 @@ void ext_desc_grid_sub( const int           ix,
 
 __global__ void ext_desc_grid(int octave, cudaTextureObject_t layer_tex)
 {
-    const int   o_offset =  dct.ori_ps[octave] + blockIdx.x;
+    const int   num      = dct.ori_ct[octave];
+    const int   offset   = blockIdx.x;
+
+    const int   o_offset =  dct.ori_ps[octave] + offset;
     const int   ix       = threadIdx.y;
     const int   iy       = threadIdx.z;
+
+    if( offset >= num ) return;
+    if( o_offset >= dct.ori_total ) return;
 
     Descriptor* desc     = &dbuf.desc           [o_offset];
     const int   ext_idx  =  dobuf.feat_to_ext_map[o_offset];

--- a/src/popsift/s_desc_igrid.cu
+++ b/src/popsift/s_desc_igrid.cu
@@ -79,8 +79,10 @@ __global__ void ext_desc_igrid(int octave, cudaTextureObject_t texLinear)
     const int   num      = dct.ori_ct[octave];
 
     const int   offset   = blockIdx.x * blockDim.z + threadIdx.z;
+
     const int   o_offset =  dct.ori_ps[octave] + offset;
     if( offset >= num ) return;
+    if( o_offset >= dct.ori_total ) return;
 
     Descriptor* desc     = &dbuf.desc           [o_offset];
     const int   ext_idx  =  dobuf.feat_to_ext_map[o_offset];

--- a/src/popsift/s_desc_iloop.cu
+++ b/src/popsift/s_desc_iloop.cu
@@ -130,7 +130,14 @@ void ext_desc_iloop_sub( const float         ang,
 
 __global__ void ext_desc_iloop(int octave, cudaTextureObject_t layer_tex, int w, int h)
 {
-    const int   o_offset =  dct.ori_ps[octave] + blockIdx.x;
+    const int   num      = dct.ori_ct[octave];
+
+    const int   offset   = blockIdx.x;
+
+    const int   o_offset =  dct.ori_ps[octave] + offset;
+    if( offset >= num ) return;
+    if( o_offset >= dct.ori_total ) return;
+
     Descriptor* desc     = &dbuf.desc           [o_offset];
     const int   ext_idx  =  dobuf.feat_to_ext_map[o_offset];
     Extremum*   ext      =  dobuf.extrema + ext_idx;

--- a/src/popsift/s_desc_loop.cu
+++ b/src/popsift/s_desc_loop.cu
@@ -140,7 +140,14 @@ void ext_desc_loop_sub( const float         ang,
 
 __global__ void ext_desc_loop(int octave, cudaTextureObject_t layer_tex, int w, int h)
 {
-    const int   o_offset =  dct.ori_ps[octave] + blockIdx.x;
+    const int   num      = dct.ori_ct[octave];
+
+    const int   offset   = blockIdx.x;
+
+    const int   o_offset =  dct.ori_ps[octave] + offset;
+    if( offset >= num ) return;
+    if( o_offset >= dct.ori_total ) return;
+
     Descriptor* desc     = &dbuf.desc           [o_offset];
     const int   ext_idx  =  dobuf.feat_to_ext_map[o_offset];
     Extremum*   ext      =  dobuf.extrema + ext_idx;

--- a/src/popsift/s_desc_notile.cu
+++ b/src/popsift/s_desc_notile.cu
@@ -105,6 +105,7 @@ void ext_desc_notile( const int           octave,
 
     const int   o_offset =  dct.ori_ps[octave] + offset;
     if( offset >= num ) return;
+    if( o_offset >= dct.ori_total ) return;
 
     Descriptor* desc     = &dbuf.desc            [o_offset];
     const int   ext_idx  =  dobuf.feat_to_ext_map[o_offset];

--- a/src/popsift/s_orientation.cu
+++ b/src/popsift/s_orientation.cu
@@ -327,7 +327,7 @@ void ori_prefix_sum( const int total_ext_ct, const int num_octaves )
     ExtremaRead r( extremum );
     ExtremaWrt  w( extremum );
     ExtremaTot  t( total_ori );
-    ExtremaWrtMap wrtm( feat_to_ext_map, max( d_consts.max_orientations, dbuf.ori_allocated ) );
+    ExtremaWrtMap wrtm( feat_to_ext_map, dbuf.ori_allocated);
     ExclusivePrefixSum::Block<ExtremaRead,ExtremaWrt,ExtremaTot,ExtremaWrtMap>( total_ext_ct, r, w, t, wrtm );
 
     __syncthreads();
@@ -356,8 +356,8 @@ void ori_prefix_sum( const int total_ext_ct, const int num_octaves )
             dct.ori_ps[o] = dct.ori_ps[o-1] + dct.ori_ct[o-1];
         }
 
-        dct.ori_total = dct.ori_ps[MAX_OCTAVES-1] + dct.ori_ct[MAX_OCTAVES-1];
-        dct.ext_total = dct.ext_ps[MAX_OCTAVES-1] + dct.ext_ct[MAX_OCTAVES-1];
+        dct.ori_total = min(dct.ori_ps[MAX_OCTAVES-1] + dct.ori_ct[MAX_OCTAVES-1], dbuf.ori_allocated);
+        dct.ext_total = min(dct.ext_ps[MAX_OCTAVES-1] + dct.ext_ct[MAX_OCTAVES-1], dbuf.ext_allocated);
     }
 }
 

--- a/src/popsift/sift_pyramid.cu
+++ b/src/popsift/sift_pyramid.cu
@@ -259,7 +259,11 @@ void prep_features( Descriptor* descriptor_base, int up_fac )
     const float xpos    = ext.xpos  * powf(2.0f, float(octave - up_fac));
     const float ypos    = ext.ypos  * powf(2.0f, float(octave - up_fac));
     const float sigma   = ext.sigma * powf(2.0f, float(octave - up_fac));
-    const int   num_ori = ext.num_ori;
+    int   num_ori = ext.num_ori;
+
+    if( ext.idx_ori + num_ori > dct.ori_total ) {
+        num_ori = max(dct.ori_total - ext.idx_ori, 0);
+    }
 
     fet.xpos    = xpos;
     fet.ypos    = ypos;


### PR DESCRIPTION
This also resolves https://github.com/alicevision/popsift/issues/105.

I am also attaching a sample image where this error happens. [1.pgm.txt](https://github.com/alicevision/popsift/files/11956962/1.pgm.txt)

## Description
This PR resolves an issue with illegal memory access when there are more orientations/descriptors than allocated. This error happens when there at least 2 times more orientations than there are extremas. There must also be at least 100k extremas for this crash to happen. You can reduce this value to get this error easier.

https://github.com/alicevision/popsift/blob/4b4b2478d5f0cdb6c4215a031572e951c0c2502e/src/popsift/sift_conf.cu#L33

I'm pasting some link for easier understanding which parts are relevant for memory allocation and its amount.
https://github.com/alicevision/popsift/blob/4b4b2478d5f0cdb6c4215a031572e951c0c2502e/src/popsift/sift_constants.cu#L30-L31
https://github.com/alicevision/popsift/blob/4b4b2478d5f0cdb6c4215a031572e951c0c2502e/src/popsift/sift_pyramid.cu#L154
https://github.com/alicevision/popsift/blob/4b4b2478d5f0cdb6c4215a031572e951c0c2502e/src/popsift/sift_pyramid.cu#L192

This part here is interesting because there is a constant `max_orientations = max_extrema + max_extrema/4; ` but the amount allocated  is then `max( 2 * h_consts.max_extrema, h_consts.max_orientations )` which does not make much sense. But that in itself is not a problem. The problem is that excess orientations are never pruned which causes problem later in the process. This makes it mandatory for checking if orientation index is within allocated memory.


## Implementation remarks
Instead of pruning excess orientations I've implemented index checking at relevant places. Pruning might be better solution but it is not as easy to implement (maybe I am wrong). If pruning was to happen I think it should be done here:
https://github.com/alicevision/popsift/blob/4b4b2478d5f0cdb6c4215a031572e951c0c2502e/src/popsift/s_orientation.cu#L328-L331



