### PR TITLE
First-order CUDA followup fix: explicit CC list for Jetson and Tegra platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,26 @@
 # First-order language CUDA requires at least CMake 3.18
 cmake_minimum_required(VERSION 3.24)
 
+# Default seletion of CUDA Compute Capabilities.
+# This must be called before project() or cmake sets it to the oldest non-deprecated CC
+# "all" and "all-major" work for Intel and perhaps for ARM with discrete GPUs, but not Tegra and Jetson.
+if(EXISTS "/etc/nv_tegra_release")
+  # The CC list for Tegras and Jetson will require manual updates
+  set(CMAKE_CUDA_ARCHITECTURES "53;62;72;87"
+      CACHE
+      STRING "Which CUDA CCs to support: native, all, all-major or an explicit list delimited by semicolons")
+else()
+  # The CC list for discrete GPUs will require CMake updates
+  set(CMAKE_CUDA_ARCHITECTURES "all-major"
+      CACHE
+      STRING "Which CUDA CCs to support: native, all, all-major or an explicit list delimited by semicolons")
+endif()
+
 project(PopSift VERSION 1.0.0 LANGUAGES CXX CUDA)
 
 # Policy to support CUDA as a first-order language for CMake.
 # Since CMake 3.18. See https://cmake.org/cmake/help/latest/policy/CMP0104.html
 cmake_policy(SET CMP0104 NEW)
-
-set(CMAKE_CUDA_ARCHITECTURES "all-major"
-    CACHE
-    STRING "Which CUDA CCs to support: native, all, all-major or an explicit list delimited by semicolons"
-    FORCE)
 
 # Set build path as a folder named as the platform (linux, windows, darwin...) plus the processor type
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")


### PR DESCRIPTION
## Description

Using CUDA as a language in CMake projects requires a CC selection in the variable CMAKE_CUDA_ARCHITECTURES.

The default here is the oldest CC supported by the installed nvcc. To have a better but not complete CC list for discrete GPUs, set CMAKE_CUDA_ARCHITECTURES to "all-major". Both fails for Tegras and Jetson because CMake guesses that these are ARM platforms with discrete GPUs.

Therefore, we test if the file /etc/nv_tegra_release exists. In this case, we guess that the intention is to compile for Tegras or Jetsons and set CMAKE_CUDA_ARCHITECTURES="53;62;72;87".

## Features list

- Select sensible CCs when PopSift is configured on a Tegra/Jetson to compile for a Tegra/Jetson.

## Implementation remarks

- We are not adding CC 32 to the list since it is deprecated. The current CUDA code may still work on CC32 platforms.
