### PR TITLE
Guard calls to nvtx directly

### DIFF
--- a/src/popsift/s_filtergrid.cu
+++ b/src/popsift/s_filtergrid.cu
@@ -11,9 +11,6 @@
 
 #if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
 #include <nvtx3/nvToolsExtCuda.h>
-#else
-#define nvtxRangePushA(a)
-#define nvtxRangePop()
 #endif
 
 #if ! POPSIFT_IS_DEFINED(POPSIFT_DISABLE_GRID_FILTER)
@@ -317,9 +314,14 @@ int Pyramid::extrema_filter_grid( const Config& conf, int ext_total )
         }
     }
 
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
     nvtxRangePushA( "writing back count" );
+#endif
+
     writeDescCountersToDevice( );
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
     nvtxRangePop( );
+#endif
 
     return ret_ext_total;
 }

--- a/src/popsift/s_image.cu
+++ b/src/popsift/s_image.cu
@@ -17,9 +17,6 @@
 
 #if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
 #include <nvtx3/nvToolsExtCuda.h>
-#else
-#define nvtxRangePushA(a)
-#define nvtxRangePop()
 #endif
 
 using namespace std;
@@ -98,7 +95,9 @@ void Image::resetDimensions( int w, int h )
         destroyTexture( );
         createTexture( );
     } else {
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
         nvtxRangePushA( "reallocating host-side image memory" );
+#endif
 
         _max_w = max( w, _max_w );
         _max_h = max( h, _max_h );
@@ -112,20 +111,26 @@ void Image::resetDimensions( int w, int h )
         destroyTexture( );
         createTexture( );
 
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
         nvtxRangePop(); // "reallocating host-side image memory"
+#endif
     }
 }
 
 void Image::allocate( int w, int h )
 {
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
     nvtxRangePushA( "allocating host-side image memory" );
+#endif
 
     _input_image_h.allocHost( w, h, popsift::CudaAllocated );
     _input_image_d.allocDev( w, h );
 
     createTexture( );
 
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
     nvtxRangePop(); // "allocating host-side image memory"
+#endif
 }
 
 void Image::destroyTexture( )
@@ -222,7 +227,9 @@ void ImageFloat::resetDimensions( int w, int h )
         destroyTexture( );
         createTexture( );
     } else {
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
         nvtxRangePushA( "reallocating host-side image memory" );
+#endif
 
         _max_w = max( w, _max_w );
         _max_h = max( h, _max_h );
@@ -236,20 +243,26 @@ void ImageFloat::resetDimensions( int w, int h )
         destroyTexture( );
         createTexture( );
 
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
         nvtxRangePop(); // "reallocating host-side image memory"
+#endif
     }
 }
 
 void ImageFloat::allocate( int w, int h )
 {
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
     nvtxRangePushA( "allocating host-side image memory" );
+#endif
 
     _input_image_h.allocHost( w, h, popsift::CudaAllocated );
     _input_image_d.allocDev( w, h );
 
     createTexture( );
 
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
     nvtxRangePop(); // "allocating host-side image memory"
+#endif
 }
 
 void ImageFloat::destroyTexture( )

--- a/src/popsift/s_orientation.cu
+++ b/src/popsift/s_orientation.cu
@@ -20,9 +20,6 @@
 
 #if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
 #include <nvtx3/nvToolsExtCuda.h>
-#else
-#define nvtxRangePushA(a)
-#define nvtxRangePop()
 #endif
 
 using namespace popsift;

--- a/src/popsift/sift_desc.cu
+++ b/src/popsift/sift_desc.cu
@@ -23,9 +23,6 @@
 
 #if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
 #include <nvtx3/nvToolsExtCuda.h>
-#else
-#define nvtxRangePushA(a)
-#define nvtxRangePop()
 #endif
 
 using namespace popsift;
@@ -55,11 +52,15 @@ using namespace std;
 __host__
 void Pyramid::descriptors( const Config& conf )
 {
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
    nvtxRangePushA("Reading orientation count");
+#endif
 
    readDescCountersFromDevice( _octaves[0].getStream() );
    cudaStreamSynchronize( _octaves[0].getStream() );
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
    nvtxRangePop( );
+#endif
 
     for( int octave=_num_octaves-1; octave>=0; octave-- )
     // for( int octave=0; octave<_num_octaves; octave++ )

--- a/src/popsift/sift_pyramid.cu
+++ b/src/popsift/sift_pyramid.cu
@@ -27,9 +27,6 @@
 
 #if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
 #include <nvtx3/nvToolsExtCuda.h>
-#else
-#define nvtxRangePushA(a)
-#define nvtxRangePop()
 #endif
 
 #define PYRAMID_PRINT_DEBUG 0
@@ -285,12 +282,18 @@ FeaturesHost* Pyramid::get_descriptors( const Config& conf )
 
     readDescCountersFromDevice();
 
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
     nvtxRangePushA( "download descriptors" );
+#endif
+
     FeaturesHost* features = new FeaturesHost( hct.ext_total, hct.ori_total );
 
     if( hct.ext_total == 0 || hct.ori_total == 0 )
     {
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
         nvtxRangePop();
+#endif
+
         return features;
     }
 
@@ -298,9 +301,16 @@ FeaturesHost* Pyramid::get_descriptors( const Config& conf )
     prep_features<<<grid,32,0,_download_stream>>>( features->getDescriptors(), up_fac );
     POP_SYNC_CHK;
 
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
     nvtxRangePushA( "register host memory" );
+#endif
+
     features->pin( );
+
+    #if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
     nvtxRangePop();
+#endif
+
     popcuda_memcpy_async( features->getFeatures(),
                           dobuf_shadow.features,
                           hct.ext_total * sizeof(Feature),
@@ -313,10 +323,14 @@ FeaturesHost* Pyramid::get_descriptors( const Config& conf )
                           cudaMemcpyDeviceToHost,
                           _download_stream );
     cudaStreamSynchronize( _download_stream );
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
     nvtxRangePushA( "unregister host memory" );
+#endif
     features->unpin( );
+#if POPSIFT_IS_DEFINED(POPSIFT_USE_NVTX)
     nvtxRangePop();
     nvtxRangePop();
+#endif
 
     return features;
 }


### PR DESCRIPTION
... rather than trying to macroize names popsift does not own.

This avoids a compile error [1] due to the macro breaking the declaration *inside NVTX* :

```c++
NVTX_DECLSPEC int NVTX_API nvtxRangePop(void);
```

note that the `(void)` means it tries to pass an argument to the **macro** nvtxRangePop because popsift is `#define`ing that macro prior to `#include`ing other CUDA headers.

Related: https://github.com/alicevision/popsift/pull/162 is probably a better fix than this but as it outright removes a feature we are hesitant to add that as a patch in vcpkg. If #162 is accepted, this PR should be closed as moot.

[1]:
```console
[1/31] cd /vcpkg/buildtrees/popsift/x64-linux-dbg/src/CMakeFiles/popsift.dir/popsift && /vcpkg/downloads/tools/cmake-3.30.1-linux/cmake-3.30.1-linux-x86_64/bin/cmake -E make_directory /vcpkg/buildtrees/popsift/x64-linux-dbg/src/CMakeFiles/popsift.dir/popsift/. && /vcpkg/downloads/tools/cmake-3.30.1-linux/cmake-3.30.1-linux-x86_64/bin/cmake -D verbose:BOOL=OFF -D build_configuration:STRING=Debug -D generated_file:STRING=/vcpkg/buildtrees/popsift/x64-linux-dbg/src/CMakeFiles/popsift.dir/popsift/./popsift_generated_s_filtergrid.cu.o -D generated_cubin_file:STRING=/vcpkg/buildtrees/popsift/x64-linux-dbg/src/CMakeFiles/popsift.dir/popsift/./popsift_generated_s_filtergrid.cu.o.cubin.txt -P /vcpkg/buildtrees/popsift/x64-linux-dbg/src/CMakeFiles/popsift.dir/popsift/popsift_generated_s_filtergrid.cu.o.Debug.cmake
FAILED: src/CMakeFiles/popsift.dir/popsift/popsift_generated_s_filtergrid.cu.o /vcpkg/buildtrees/popsift/x64-linux-dbg/src/CMakeFiles/popsift.dir/popsift/popsift_generated_s_filtergrid.cu.o
cd /vcpkg/buildtrees/popsift/x64-linux-dbg/src/CMakeFiles/popsift.dir/popsift && /vcpkg/downloads/tools/cmake-3.30.1-linux/cmake-3.30.1-linux-x86_64/bin/cmake -E make_directory /vcpkg/buildtrees/popsift/x64-linux-dbg/src/CMakeFiles/popsift.dir/popsift/. && /vcpkg/downloads/tools/cmake-3.30.1-linux/cmake-3.30.1-linux-x86_64/bin/cmake -D verbose:BOOL=OFF -D build_configuration:STRING=Debug -D generated_file:STRING=/vcpkg/buildtrees/popsift/x64-linux-dbg/src/CMakeFiles/popsift.dir/popsift/./popsift_generated_s_filtergrid.cu.o -D generated_cubin_file:STRING=/vcpkg/buildtrees/popsift/x64-linux-dbg/src/CMakeFiles/popsift.dir/popsift/./popsift_generated_s_filtergrid.cu.o.cubin.txt -P /vcpkg/buildtrees/popsift/x64-linux-dbg/src/CMakeFiles/popsift.dir/popsift/popsift_generated_s_filtergrid.cu.o.Debug.cmake
nvcc warning : Support for offline compilation for architectures prior to '<compute/sm/lto>_75' will be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning).
In file included from /usr/local/cuda-12.9/include/nvtx3/nvtx3.hpp:657,
                 from /usr/local/cuda-12.9/include/cub/detail/nvtx.cuh:56,
                 from /usr/local/cuda-12.9/include/cub/device/device_for.cuh:40,
                 from /usr/local/cuda-12.9/include/thrust/system/cuda/detail/parallel_for.h:43,
                 from /usr/local/cuda-12.9/include/thrust/system/cuda/detail/swap_ranges.h:43,
                 from /usr/local/cuda-12.9/include/thrust/system/detail/adl/swap_ranges.h:50,
                 from /usr/local/cuda-12.9/include/thrust/detail/swap_ranges.inl:31,
                 from /usr/local/cuda-12.9/include/thrust/swap.h:147,
                 from /usr/local/cuda-12.9/include/thrust/system/cuda/detail/iter_swap.h:34,
                 from /usr/local/cuda-12.9/include/thrust/system/detail/adl/iter_swap.h:50,
                 from /usr/local/cuda-12.9/include/thrust/detail/reference.h:37,
                 from /usr/local/cuda-12.9/include/thrust/memory.h:35,
                 from /usr/local/cuda-12.9/include/thrust/detail/allocator/temporary_allocator.h:31,
                 from /usr/local/cuda-12.9/include/thrust/detail/temporary_array.h:46,
                 from /usr/local/cuda-12.9/include/thrust/system/cuda/detail/internal/copy_cross_system.h:47,
                 from /usr/local/cuda-12.9/include/thrust/system/cuda/detail/copy.h:79,
                 from /usr/local/cuda-12.9/include/thrust/system/detail/adl/copy.h:50,
                 from /usr/local/cuda-12.9/include/thrust/detail/copy.inl:29,
                 from /usr/local/cuda-12.9/include/thrust/detail/copy.h:72,
                 from /usr/local/cuda-12.9/include/thrust/copy.h:505,
                 from /vcpkg/buildtrees/popsift/src/v0.9-ba1d7e1254.clean/src/popsift/s_filtergrid.cu:21:
/usr/local/cuda-12.9/include/nvtx3/nvToolsExt.h:1063:45: error: macro "nvtxRangePop" passed 1 arguments, but takes just 0
 1063 | NVTX_DECLSPEC int NVTX_API nvtxRangePop(void);
      |                                             ^
/vcpkg/buildtrees/popsift/src/v0.9-ba1d7e1254.clean/src/popsift/s_filtergrid.cu:16: note: macro "nvtxRangePop" defined here
   16 | #define nvtxRangePop()
      |
In file included from /usr/local/cuda-12.9/include/nvtx3/nvtxDetail/nvtxImpl.h:367,
                 from /usr/local/cuda-12.9/include/nvtx3/nvToolsExt.h:1619,
                 from /usr/local/cuda-12.9/include/nvtx3/nvtx3.hpp:657,
                 from /usr/local/cuda-12.9/include/cub/detail/nvtx.cuh:56,
                 from /usr/local/cuda-12.9/include/cub/device/device_for.cuh:40,
                 from /usr/local/cuda-12.9/include/thrust/system/cuda/detail/parallel_for.h:43,
                 from /usr/local/cuda-12.9/include/thrust/system/cuda/detail/swap_ranges.h:43,
                 from /usr/local/cuda-12.9/include/thrust/system/detail/adl/swap_ranges.h:50,
                 from /usr/local/cuda-12.9/include/thrust/detail/swap_ranges.inl:31,
                 from /usr/local/cuda-12.9/include/thrust/swap.h:147,
                 from /usr/local/cuda-12.9/include/thrust/system/cuda/detail/iter_swap.h:34,
                 from /usr/local/cuda-12.9/include/thrust/system/detail/adl/iter_swap.h:50,
                 from /usr/local/cuda-12.9/include/thrust/detail/reference.h:37,
                 from /usr/local/cuda-12.9/include/thrust/memory.h:35,
                 from /usr/local/cuda-12.9/include/thrust/detail/allocator/temporary_allocator.h:31,
                 from /usr/local/cuda-12.9/include/thrust/detail/temporary_array.h:46,
                 from /usr/local/cuda-12.9/include/thrust/system/cuda/detail/internal/copy_cross_system.h:47,
                 from /usr/local/cuda-12.9/include/thrust/system/cuda/detail/copy.h:79,
                 from /usr/local/cuda-12.9/include/thrust/system/detail/adl/copy.h:50,
                 from /usr/local/cuda-12.9/include/thrust/detail/copy.inl:29,
                 from /usr/local/cuda-12.9/include/thrust/detail/copy.h:72,
                 from /usr/local/cuda-12.9/include/thrust/copy.h:505,
                 from /vcpkg/buildtrees/popsift/src/v0.9-ba1d7e1254.clean/src/popsift/s_filtergrid.cu:21:
/usr/local/cuda-12.9/include/nvtx3/nvtxDetail/nvtxImplCore.h:133:45: error: macro "nvtxRangePop" passed 1 arguments, but takes just 0
  133 | NVTX_DECLSPEC int NVTX_API nvtxRangePop(void)
      |                                             ^
/vcpkg/buildtrees/popsift/src/v0.9-ba1d7e1254.clean/src/popsift/s_filtergrid.cu:16: note: macro "nvtxRangePop" defined here
   16 | #define nvtxRangePop()
      |
CMake Error at popsift_generated_s_filtergrid.cu.o.Debug.cmake:220 (message):
  Error generating
  /vcpkg/buildtrees/popsift/x64-linux-dbg/src/CMakeFiles/popsift.dir/popsift/./popsift_generated_s_filtergrid.cu.o
```