### PR TITLE
[sift] removed support for the old option for Gaussian filter width computation opencv

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed option to create top level of every octave from input image [PR](https://github.com/alicevision/popsift/pull/178)
-- Removed option to compute very narrow Gaussian filters called opencv [PR]
+- Removed option to compute very narrow Gaussian filters called opencv [PR](https://github.com/alicevision/popsift/pull/179)
 
 ## [0.10.0] - 2025-10-14
 

--- a/src/popsift/sift_conf.cu
+++ b/src/popsift/sift_conf.cu
@@ -115,7 +115,10 @@ void Config::setGaussMode( const std::string& m )
         setGaussMode( Config::Fixed9 );
     else if( m == "fixed15" )
         setGaussMode( Config::Fixed15 );
-    else
+    else if( m == "opencv" ) {
+        POP_WARN( string("Gauss mode 'opencv' has been deprecated. Using mode vlfeat instead.\n") );
+        setGaussMode( Config::VLFeat_Compute );
+    } else
         POP_FATAL( string("Bad Gauss mode.\n") + getGaussModeUsage() );
 }
 


### PR DESCRIPTION
## Description

- Remove unreachable code for extrema search in interpolated DoG planes

Extrema are searched from 3x3x3 blocks of pixels in the DoG pyramid. The dead code could search in interpolated pixels, which never made sense. The code was always #undef'ed.

- Remove the narrow Gaussian filter option "--gauss-mode opencv"

OpenCV used quite narrow Gaussian filters when PopSift was first written. This computation was adopted for compatibility reasons, but the missing elements in the filter do actually have a noticable impact. The other modes are more accurate.

## Features list

- Remove unreachable code for extrema search in interpolated DoG planes
- Remove the narrow Gaussian filter option "--gauss-mode opencv"

## Implementation remarks

There are still Gaussian filter modes that should be retired. The fixed filter with width 9 provides bad quality, while the fixed filter with width 15 is needlessly slow.
