### PR TITLE
[sift] Remove unreachable code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed option to create top level of every octave from input image [PR](https://github.com/alicevision/popsift/pull/178)
 - Removed option to compute very narrow Gaussian filters called opencv [PR](https://github.com/alicevision/popsift/pull/179)
+- Removed unreachable code for alternative downscaling between octaves [PR](https://github.com/alicevision/popsift/pull/180)
 
 ## [0.10.0] - 2025-10-14
 

--- a/src/popsift/s_pyramid_build.cu
+++ b/src/popsift/s_pyramid_build.cu
@@ -30,24 +30,6 @@ namespace popsift {
 namespace gauss {
 
 __global__
-void get_by_2_interpolate( cudaTextureObject_t src_data,
-                           const int           src_level,
-                           cudaSurfaceObject_t dst_data,
-                           const int           dst_w,
-                           const int           dst_h )
-{
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    const int idy = blockIdx.y * blockDim.y + threadIdx.y;
-
-    if( idx >= dst_w ) return;
-    if( idy >= dst_h ) return;
-
-    const float val = readTex( src_data, 2.0f * idx + 1.0f, 2.0f * idy + 1.0f, src_level );
-
-    surf2DLayeredwrite( val, dst_data, idx*4, idy, 0, cudaBoundaryModeZero ); // dst_data.ptr(idy)[idx] = val;
-}
-
-__global__
 void get_by_2_pick_every_second( cudaTextureObject_t src_data,
                                  const int           src_w,
                                  const int           src_h,
@@ -214,35 +196,17 @@ inline void Pyramid::downscale_from_prev_octave( int octave, cudaStream_t stream
     h_grid.x = (unsigned int)grid_divide( width,  h_block.x );
     h_grid.y = (unsigned int)grid_divide( height, h_block.y );
 
-    switch( mode )
-    {
-    case Config::PopSift :
-    case Config::VLFeat :
-    case Config::OpenCV :
-        gauss::get_by_2_pick_every_second
-            <<<h_grid,h_block,0,stream>>>
-            ( prev_oct_obj.getDataTexPoint( ),
-              prev_oct_obj.getWidth(),
-              prev_oct_obj.getHeight(),
-              _levels-PREV_LEVEL,
-              oct_obj.getDataSurface( ),
-              oct_obj.getWidth(),
-              oct_obj.getHeight() );
+    gauss::get_by_2_pick_every_second
+        <<<h_grid,h_block,0,stream>>>
+        ( prev_oct_obj.getDataTexPoint( ),
+          prev_oct_obj.getWidth(),
+          prev_oct_obj.getHeight(),
+          _levels-PREV_LEVEL,
+          oct_obj.getDataSurface( ),
+          oct_obj.getWidth(),
+          oct_obj.getHeight() );
 
-        POP_SYNC_CHK;
-        break;
-    default :
-        gauss::get_by_2_interpolate
-            <<<h_grid,h_block,0,stream>>>
-            ( prev_oct_obj.getDataTexLinear( ).tex,
-              _levels-PREV_LEVEL,
-              oct_obj.getDataSurface( ),
-              oct_obj.getWidth(),
-              oct_obj.getHeight() );
-
-        POP_SYNC_CHK;
-        break;
-    }
+    POP_SYNC_CHK;
 }
 
 __host__

--- a/src/popsift/sift_conf.h
+++ b/src/popsift/sift_conf.h
@@ -366,7 +366,7 @@ private:
     /// default: 1
     int  _filter_grid_size;
 
-    /// Modes are computation according to VLFeat or OpenCV,
+    /// Modes are computation according to VLFeat
     /// or fixed size. Default is VLFeat mode.
     GaussMode _gauss_mode;
 


### PR DESCRIPTION
## Description

This removes one of two alternatives for downscaling from the 3rd last layer of an octave to the first layer of the next octave. There were two alternatives:
(1) pick only the even pixels from the even rows (this version is retained)
(2) perform a linear interpolation between a square of 4 pixels (this version is removed)

The second approach was now unreachable code that replicated buggy OpenCV behaviour that existed in 2016.
The real bug was not in the downscaling according to (2), it was that everything else in the code was indexed as if (1) had been used.
In PopSift, this case has not been reachable with any valid command line or library parameter for a long time because it led to errors in feature position computations.

## Features list

- Remove practically unreachable alternative code for downscaling between octaves
