### PR TITLE
Add /Zc:preprocessor for CUDA 13.2 on MSVC.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,9 @@ target_link_libraries(popsift
 set_target_properties(popsift PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(popsift PROPERTIES DEBUG_POSTFIX "d")
 set_target_properties(popsift PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+if(MSVC)
+        target_compile_options(popsift PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/Zc:preprocessor>)
+endif()
 
 # build directory containing the automatically generated files
 set(popsift_generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")


### PR DESCRIPTION
This change was prepared with assistance from GPT 5.4.

## Checklist

Related: https://github.com/microsoft/vcpkg/pull/51210

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
      The guidelines there suggest creating an issue but that seems to be about adding a new feature or major change and I don't think this qualifies so I haven't created one.
- [x] I have updated the documentation, if applicable.
      (Not applicable)
- [x] I have ensured that the change is tested somewhere.
      It works on my machine™️
- [x] I have followed the prevailing code style (for history readability and limit conflicts for maintenance).
      GPT 5.4 actually failed at this and I had to fix it 😅. I observe that this file has some indents using tabs and others using spaces. It seems like tabs are *most* of the time. I would reindent them all to use 8 spaces but that would have made the patch much larger, so I'm initially only submitting this 3 line change.
      <img width="572" height="407" alt="screenshot with visible whitespace showing some tabs" src="https://github.com/user-attachments/assets/b38aae34-9b92-41f1-915d-c9782d5938f7" />


## Description

Hopefully resolves the following build error:

```
Run Build Command(s): D:\downloads\tools\ninja-1.13.2-windows\ninja.exe -v -v -j33 install
[1/32] C:\PROGRA~1\NVIDIA~2\CUDA\v13.2\bin\nvcc.exe -forward-unknown-to-host-compiler -Dpopsift_EXPORTS -ID:\b\popsift\src\v0.10.0-4df863d942.clean\src -ID:\b\popsift\x64-windows-dbg\src\generated -ID:\b\popsift\x64-windows-dbg\src\generated\popsift -isystem "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\include" -isystem "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\include\cccl" -D_WINDOWS -Xcompiler=" /EHsc" -Xcompiler=" -Zi -Ob0 -Od /RTC1" -std=c++17 -arch=all-major -Xcompiler=-MDd -MD -MT src\CMakeFiles\popsift.dir\popsift\s_filtergrid.cu.obj -MF src\CMakeFiles\popsift.dir\popsift\s_filtergrid.cu.obj.d -x cu -rdc=true -c D:\b\popsift\src\v0.10.0-4df863d942.clean\src\popsift\s_filtergrid.cu -o src\CMakeFiles\popsift.dir\popsift\s_filtergrid.cu.obj -Xcompiler=-Fdsrc\CMakeFiles\popsift.dir\,-FS
FAILED: [code=2] src/CMakeFiles/popsift.dir/popsift/s_filtergrid.cu.obj
C:\PROGRA~1\NVIDIA~2\CUDA\v13.2\bin\nvcc.exe -forward-unknown-to-host-compiler -Dpopsift_EXPORTS -ID:\b\popsift\src\v0.10.0-4df863d942.clean\src -ID:\b\popsift\x64-windows-dbg\src\generated -ID:\b\popsift\x64-windows-dbg\src\generated\popsift -isystem "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\include" -isystem "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\include\cccl" -D_WINDOWS -Xcompiler=" /EHsc" -Xcompiler=" -Zi -Ob0 -Od /RTC1" -std=c++17 -arch=all-major -Xcompiler=-MDd -MD -MT src\CMakeFiles\popsift.dir\popsift\s_filtergrid.cu.obj -MF src\CMakeFiles\popsift.dir\popsift\s_filtergrid.cu.obj.d -x cu -rdc=true -c D:\b\popsift\src\v0.10.0-4df863d942.clean\src\popsift\s_filtergrid.cu -o src\CMakeFiles\popsift.dir\popsift\s_filtergrid.cu.obj -Xcompiler=-Fdsrc\CMakeFiles\popsift.dir\,-FS
C:\PROGRA~1\NVIDIA~2\CUDA\v13.2\include\cccl\cuda/std/__cccl/preprocessor.h(23): fatal error C1189: #error:  MSVC/cl.exe with traditional preprocessor is used. This may lead to unexpected compilation errors. Please switch to the standard conforming preprocessor by passing `/Zc:preprocessor` to cl.exe. You can define CCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING to suppress this warning.
s_filtergrid.cu
```

## Features list

Not applicable.

## Implementation remarks

Not applicable. (Other than what's already mentioned in the checklist)
