### PR TITLE
Fix checklist typo and use a consistent number of spaces around headings.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
  - I have read the [contribution guidelines](../CONTRIBUTING.md).
  - I have updated the documentation, if applicable.
  - I have ensured that the change is tested somewhere.
- - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).
+ - I have followed the prevailing code style (for history readability and limit conflicts for maintenance).
 
 -->
 ## Description
@@ -19,9 +19,7 @@
 - [X] Add "X" when it is done.
 -->
 
-
 ## Implementation remarks
-
 
 <!--
 Explain main implementation choices.


### PR DESCRIPTION
I noticed this while filling out the checklist for https://github.com/alicevision/popsift/pull/183

No AI was used in authoring this change.