### PR TITLE
[ci] no need for the windows generator

### DIFF
--- a/.github/scripts/build-windows.ps1
+++ b/.github/scripts/build-windows.ps1
@@ -53,14 +53,13 @@ function Configure-CMake {
     $vcpkgToolchain = "$VcpkgRoot/scripts/buildsystems/vcpkg.cmake"
     
     Set-Location $buildDir
-    cmake .. -G "Visual Studio 17 2022" -A x64 `
+    cmake .. `
       -DBUILD_SHARED_LIBS:BOOL=ON `
       -DCMAKE_GENERATOR_TOOLSET="cuda=$env:CUDA_PATH" `
       -DPopSift_USE_GRID_FILTER:BOOL=ON `
       -DPopSift_BUILD_DOCS:BOOL=OFF `
       -DPopSift_USE_POSITION_INDEPENDENT_CODE:BOOL=ON `
       -DPopSift_BUILD_EXAMPLES:BOOL=ON `
-      -DCMAKE_BUILD_TYPE="$BuildType" `
       -DCMAKE_INSTALL_PREFIX="$installDir" `
       -DVCPKG_INSTALLED_DIR="$env:VCPKG_INSTALLED_DIR" `
       -DCMAKE_TOOLCHAIN_FILE="$vcpkgToolchain"
@@ -140,7 +139,7 @@ function Build-AsThirdParty {
     Get-ChildItem -Path $mainProjectVcpkgInstalled -Directory | ForEach-Object { Write-Host " - $($_.Name)" }
 
     Set-Location $thirdPartyDir
-    cmake ../src/application -G "Visual Studio 17 2022" -A x64 `
+    cmake ../src/application `
       -DBUILD_SHARED_LIBS:BOOL=ON `
       -DCMAKE_BUILD_TYPE=$BuildType `
       -DCMAKE_PREFIX_PATH="$installDir;$mainProjectVcpkgInstalled/x64-windows" `

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -58,7 +58,7 @@ jobs:
           deps-install-dir: ${{ env.DEPS_INSTALL_DIR }}
 
   build-windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         cuda_version: ["12.5.1", "12.9.0"]

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,7 +36,7 @@ jobs:
       CTEST_OUTPUT_ON_FAILURE: 1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: Make scripts executable
         run: chmod +x ./.github/scripts/*.sh
@@ -68,12 +68,12 @@ jobs:
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}\vcpkg\vcpkg_installed
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Cache CUDA installation
       - name: Cache CUDA installation
         id: cache-cuda
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA
@@ -145,7 +145,7 @@ jobs:
       # Cache vcpkg installation and dependencies
       - name: Cache vcpkg
         id: cache-vcpkg
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ${{ env.VCPKG_SRC_DIR }}


### PR DESCRIPTION
Build was failing on Windows due to the switch to the new version of windows latest.
When using vcpkg, there is no need to explicitly specify the generator and the architecture; it will be resolved automatically.