### PR TITLE
Include Thrust tuple and zip iterator headers

### DIFF
--- a/src/popsift/s_filtergrid.cu
+++ b/src/popsift/s_filtergrid.cu
@@ -18,10 +18,12 @@
 #include <thrust/host_vector.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/transform_scan.h>
+#include <thrust/tuple.h>
 #include <thrust/version.h>
 
 namespace popsift
@@ -334,4 +336,3 @@ int Pyramid::extrema_filter_grid( const Config& conf, int ext_total )
 }; // namespace popsift
 
 #endif // not defined(DISABLE_GRID_FILTER)
-


### PR DESCRIPTION
CUDA 13.3 no longer exposes these declarations transitively. Include the headers used by s_filtergrid.cu so thrust::tuple, thrust::make_tuple, and thrust::make_zip_iterator remain available.

This change authored by GPT 5.6-Sol

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (N/A)
- [x] I have ensured that the change is tested somewhere. (Works on my machine :) )
- [x] I have followed the prevailing code style (for history readability and limit conflicts for maintenance).