### PR TITLE
[cuda] avoid a thrust version warning in CUDA 12

### DIFF
--- a/src/popsift/s_filtergrid.cu
+++ b/src/popsift/s_filtergrid.cu
@@ -286,7 +286,7 @@ int Pyramid::extrema_filter_grid( const Config& conf, int ext_total )
 
         if( ocount > 0 ) {
             FunctionExtractIgnored fun_extract_ignore;
-#if THRUST_VERSION >= 300000
+#if THRUST_VERSION >= 200802
             ::cuda::std::identity  fun_id;
 #else
             thrust::identity<int>  fun_id;


### PR DESCRIPTION
## Description

Testing PR #188 showed a Thrust version warning for CUDA 12. This was because of a compile-time Thurst version check for THRUST_VERSION >= 300000
The warning appeared already for the older Thrust version 200802. This PR updates only this version test.

## Features list

- Avoid a warning for Thrust version 200802
